### PR TITLE
Unique storage account

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <jenkins.version>1.642.1</jenkins.version>
     <java.level>7</java.level>
     <findbugs.failOnError>false</findbugs.failOnError>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <licenses>

--- a/src/main/webapp/help-storageAccountName.html
+++ b/src/main/webapp/help-storageAccountName.html
@@ -1,6 +1,8 @@
 <div>
-	Specify a storage account name. Leave blank to create a new storage account using the default name &quot;jenkinsarmst&quot;.<br />
-    <br />
+	Specify a storage account name. Leave blank to create a new storage account.<br />
+        <br/>
+        <b>The storage account name has to be unique across Azure!</b>
+        <br />
 	The maximum length of the Name element is 64 characters, only alphanumeric characters and underscores are valid in the Name, 
     and the name must start with a letter. Attempting to use other characters, starting the Name with a non-letter character, 
     or entering a name that is identical to that of another extended property owned by the same storage account, 


### PR DESCRIPTION
The storage account name has to be globally unique, not just per resource group name.
I've added the subscription id as part of the hash generation to ensure that.

Reported bug: https://issues.jenkins-ci.org/browse/JENKINS-40288
