### PR TITLE
Reconnect the session after executing the Init Script

### DIFF
--- a/src/main/java/com/microsoft/azure/remote/AzureVMAgentSSHLauncher.java
+++ b/src/main/java/com/microsoft/azure/remote/AzureVMAgentSSHLauncher.java
@@ -159,6 +159,15 @@ public class AzureVMAgentSSHLauncher extends ComputerLauncher {
                 } else {
                     LOGGER.info("AzureVMAgentSSHLauncher: launch: init script got executed successfully");
                 }
+                /* Create a new session after the init script has executed to
+                 * make sure we pick up whatever new settings have been set up
+                 * for our user
+                 *
+                 * https://issues.jenkins-ci.org/browse/JENKINS-40291
+                 */
+                 session.disconnect();
+                 session = connectToSsh(agent);
+ 
                 // Create tracking file
                 executeRemoteCommand(session, "touch ~/.azure-agent-init", logger);
             }


### PR DESCRIPTION
Moved it from the slave plugin: https://github.com/jenkinsci/azure-slave-plugin/pull/39

…ck up new  settings

In scenarios where new shells, groups, user settings or other environmental
changes which are made by the 'Init Script', this patch will ensure that the
launching of the `slave.jar` will pick those changes as part of the launched
Jenkins agent

Fixes JENKINS-40291