### PR TITLE
Should create the number of possible agents, not the desired number

### DIFF
--- a/src/main/java/com/microsoft/azure/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/AzureVMCloud.java
@@ -526,7 +526,7 @@ public class AzureVMCloud extends Cloud {
                 };
                 final Future<AzureVMDeploymentInfo> deploymentFuture = getThreadPool().submit(callableTask);
 
-                for (int i = 0; i < numberOfAgents; i++) {
+                for (int i = 0; i < numberOfNewAgents; i++) {
                     final int index = i;
                     plannedNodes.add(new PlannedNode(
                             template.getTemplateName(),


### PR DESCRIPTION
While stress testing I noticed that jenkins was going crazy.  Turns out it was attempting to allocate over the total number of allowed agents (until the max number was reached)