### PR TITLE
Add the possibility to set a resource group name for the vnet

### DIFF
--- a/src/main/java/com/microsoft/azure/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/AzureVMAgentTemplate.java
@@ -122,6 +122,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
     private final int retentionTimeInMin;
 
     private String virtualNetworkName;
+    
+    private String virtualNetworkResourceGroupName;
 
     private String subnetName;
 
@@ -165,6 +167,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
             final String initScript,
             final String credentialsId,
             final String virtualNetworkName,
+            final String virtualNetworkResourceGroupName,
             final String subnetName,
             final String agentWorkspace,
             final String jvmOptions,
@@ -201,6 +204,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
         this.agentLaunchMethod = agentLaunchMethod;
         this.credentialsId = credentialsId;
         this.virtualNetworkName = virtualNetworkName;
+        this.virtualNetworkResourceGroupName = virtualNetworkResourceGroupName;
         this.subnetName = subnetName;
         this.agentWorkspace = agentWorkspace;
         this.jvmOptions = jvmOptions;
@@ -301,7 +305,15 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
     public void setVirtualNetworkName(String virtualNetworkName) {
         this.virtualNetworkName = virtualNetworkName;
     }
+    
+    public String getVirtualNetworkResourceGroupName() {
+        return this.virtualNetworkResourceGroupName;
+    }
 
+    public void setVirtualNetworkResourceGroupName(String virtualNetworkResourceGroupName) {
+        this.virtualNetworkResourceGroupName = virtualNetworkResourceGroupName;
+    }
+    
     public String getSubnetName() {
         return subnetName;
     }
@@ -470,6 +482,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                 initScript,
                 credentialsId,
                 virtualNetworkName,
+                virtualNetworkResourceGroupName,
                 subnetName,
                 retentionTimeInMin + "",
                 jvmOptions,
@@ -663,6 +676,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                 @QueryParameter String initScript,
                 @QueryParameter String credentialsId,
                 @QueryParameter String virtualNetworkName,
+                @QueryParameter String virtualNetworkResourceGroupName,
                 @QueryParameter String subnetName,
                 @QueryParameter String retentionTimeInMin,
                 @QueryParameter String jvmOptions) {
@@ -694,9 +708,10 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                     + "initScript: {18};\n\t"
                     + "credentialsId: {19};\n\t"
                     + "virtualNetworkName: {20};\n\t"
-                    + "subnetName: {21};\n\t"
-                    + "retentionTimeInMin: {22};\n\t"
-                    + "jvmOptions: {23};",
+                    + "virtualNetworkResourceGroupName: {21};\n\t"
+                    + "subnetName: {22};\n\t"
+                    + "retentionTimeInMin: {23};\n\t"
+                    + "jvmOptions: {24};",
                     new Object[]{
                         servicePrincipal.subscriptionId.getPlainText(),
                         (StringUtils.isNotBlank(servicePrincipal.clientId.getPlainText()) ? "********" : null),
@@ -719,6 +734,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                         initScript,
                         credentialsId,
                         virtualNetworkName,
+                        virtualNetworkResourceGroupName,
                         subnetName,
                         retentionTimeInMin,
                         jvmOptions});
@@ -749,6 +765,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                     initScript,
                     credentialsId,
                     virtualNetworkName,
+                    virtualNetworkResourceGroupName,
                     subnetName,
                     retentionTimeInMin,
                     jvmOptions,

--- a/src/main/resources/com/microsoft/azure/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/AzureVMAgentTemplate/config.jelly
@@ -91,6 +91,10 @@
         <f:textbox />
       </f:entry>
 
+      <f:entry title="${%VirtualNetworkResourceGroup_Name}" field="virtualNetworkResourceGroupName" help="/plugin/azure-vm-agents/help-virtualNetworkResourceGroupName.html">
+        <f:textbox />
+      </f:entry>
+
       <f:entry title="${%Subnet_Name}" field="subnetName" help="/plugin/azure-vm-agents/help-subnetName.html">
         <f:textbox />
       </f:entry>
@@ -121,6 +125,6 @@
       </div>
     </f:entry>
     <f:validateButton title="${%Verify_Template}" progress="${%Verifying_Template_MSG}" method="verifyConfiguration"
-          with="azureCredentialsId,resourceGroupName,maxVirtualMachinesLimit,deploymentTimeout,templateName,labels,location,virtualMachineSize,storageAccountName,noOfParallelJobs,image,osType,imagePublisher,imageOffer,imageSku,imageVersion,agentLaunchMethod,initScript,credentialsId,virtualNetworkName,subnetName,retentionTimeInMin,jvmOptions" />
+          with="azureCredentialsId,resourceGroupName,maxVirtualMachinesLimit,deploymentTimeout,templateName,labels,location,virtualMachineSize,storageAccountName,noOfParallelJobs,image,osType,imagePublisher,imageOffer,imageSku,imageVersion,agentLaunchMethod,initScript,credentialsId,virtualNetworkName,virtualNetworkResourceGroupName,subnetName,retentionTimeInMin,jvmOptions" />
   </table>
 </j:jelly>

--- a/src/main/resources/com/microsoft/azure/AzureVMAgentTemplate/config.properties
+++ b/src/main/resources/com/microsoft/azure/AzureVMAgentTemplate/config.properties
@@ -40,5 +40,6 @@ Delete_Template=Delete Template
 Verify_Template=Verify Template
 Verifying_Template_MSG=Verifying Template, this may take time. Please wait...
 VirtualNetwork_Name=Virtual Network Name
+VirtualNetworkResourceGroup_Name=Virtual Network Resource Group Name
 Subnet_Name=Subnet Name
 shutdownOnIdle=Shutdown Only (Do Not Delete) After Retention Time

--- a/src/main/resources/com/microsoft/azure/Messages.properties
+++ b/src/main/resources/com/microsoft/azure/Messages.properties
@@ -44,7 +44,7 @@ Azure_GC_Template_UN_Null_Or_Empty=Missing admin user name.
 Azure_GC_Template_PWD_Null_Or_Empty=Missing admin password.
 Azure_GC_Template_PWD_Not_Valid=Required: Not a valid password. The password length must be between 8 and 123 characters. It also needs to have at least one digit, one lowercase and one uppercase letter.
 Azure_GC_Template_VirtualNetwork_Null_Or_Empty=Missing virtual network name.
-Azure_GC_Template_VirtualNetwork_NotFound=The virtual network {0} does not exist in this subscription.
+Azure_GC_Template_VirtualNetwork_NotFound=The virtual network {0} does not exist in the resource group {1} in this subscription.
 Azure_GC_Template_subnet_NotFound=The subnet {0} does not belong to the specified virtual network.
 
 Azure_Template_Config_Success=Verified the template configuration successfully.

--- a/src/main/resources/customImageTemplate.json
+++ b/src/main/resources/customImageTemplate.json
@@ -5,9 +5,10 @@
     },
     "variables": {
         "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
         "subnetName": "",
         "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
         "storageAccountContainerName": "[uniqueString(resourceGroup().id, deployment().name)]",

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -8,9 +8,10 @@
     },
     "variables": {
         "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
         "subnetName": "",
         "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
         "storageAccountContainerName": "[uniqueString(resourceGroup().id, deployment().name)]",

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -5,9 +5,10 @@
     },
     "variables": {
         "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
         "subnetName": "",
         "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
         "storageAccountContainerName": "vhds",

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -8,9 +8,10 @@
     },
     "variables": {
         "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
         "subnetName": "",
         "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
         "storageAccountContainerName": "vhds",

--- a/src/main/webapp/help-virtualNetworkResourceGroupName.html
+++ b/src/main/webapp/help-virtualNetworkResourceGroupName.html
@@ -1,0 +1,1 @@
+The name of an existing resource group in Azure where the virtual network is located. If left blank, the resourceGroup as specified in the General Configuration section of the template is used.


### PR DESCRIPTION
When the new parameter is used, the virtual network is searched in the designed resource group, instead of the default resource group as provided in the azure cloud settings.