### PR TITLE
Fix help messages in template configuration

### DIFF
--- a/src/main/webapp/help-doNotUseMachineIfInitFails.html
+++ b/src/main/webapp/help-doNotUseMachineIfInitFails.html
@@ -1,4 +1,4 @@
 <div>
-	If checked, the Azure node will execute the startup script as root.
+	If checked, the Azure node will be discarded if the initialization script returns a non-zero exit code.
     <b>Currently applies to Linux nodes only.</b>
 </div>

--- a/src/main/webapp/help-executeInitScriptAsRoot.html
+++ b/src/main/webapp/help-executeInitScriptAsRoot.html
@@ -1,4 +1,4 @@
 <div>
-	If checked, the Azure node will be discarded if the initialization script returns a non-zero exit code.
+	If checked, the Azure node will execute the startup script as root.
     <b>Currently applies to Linux nodes only.</b>
 </div>


### PR DESCRIPTION
The help texts for `Run Initialization Script As Root (Linux Only)` and `Dont Use VM If Initialization Script Fails (Linux Only)` were swapped.