### PR TITLE
Tag deployed resources and remove them if they leak [FIXED JENKINS-41330]

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -198,6 +198,8 @@ public class AzureVMManagementServiceDelegate {
 
             ObjectNode.class.cast(tmp.get("variables")).put("vmName", vmBaseName);
             ObjectNode.class.cast(tmp.get("variables")).put("location", locationName);
+            ObjectNode.class.cast(tmp.get("variables")).put("jenkinsTag", Constants.AZURE_JENKINS_TAG_VALUE);
+            ObjectNode.class.cast(tmp.get("variables")).put("resourceTag", deploymentRegistrar.getDeploymentTag().get());
 
             if (StringUtils.isNotBlank(template.getImagePublisher())) {
                 ObjectNode.class.cast(tmp.get("variables")).put("imagePublisher", template.getImagePublisher());
@@ -798,25 +800,7 @@ public class AzureVMManagementServiceDelegate {
 
                     // Now remove the disks
                     for (URI diskUri : diskUrisToRemove) {
-                        // Obtain container, storage account, and blob name
-                        String storageAccountName = diskUri.getHost().split("\\.")[0];
-                        String containerName = PathUtility.getContainerNameFromUri(diskUri, false);
-                        String blobName = PathUtility.getBlobNameFromURI(diskUri, false);
-
-                        LOGGER.log(Level.INFO, "AzureVMManagementServiceDelegate: terminateVirtualMachine: Removing disk blob {0}, in container {1} of storage account {2}",
-                                new Object[]{blobName, containerName, storageAccountName});
-
-                        List<StorageAccountKey> storageKeys = azureClient.storageAccounts()
-                            .getByGroup(resourceGroupName, storageAccountName)
-                            .getKeys();
-                        if (!storageKeys.isEmpty()) {
-                            String storageAccountKey = storageKeys.get(0).value();
-                            CloudStorageAccount account = new CloudStorageAccount(new StorageCredentialsAccountAndKey(storageAccountName, storageAccountKey));
-                            CloudBlobClient blobClient = account.createCloudBlobClient();
-                            blobClient.getContainerReference(containerName)
-                                    .getBlockBlobReference(blobName)
-                                    .deleteIfExists();
-                        }
+                        AzureVMManagementServiceDelegate.removeStorageBlob(azureClient, diskUri, resourceGroupName);
                     }
                 }
             } catch (Exception e) {
@@ -841,6 +825,28 @@ public class AzureVMManagementServiceDelegate {
             LOGGER.log(Level.INFO,
                     "AzureVMManagementServiceDelegate: terminateVirtualMachine: unrecoverable exception deleting VM",
                     uce);
+        }
+    }
+
+    public static void removeStorageBlob(final Azure azureClient, final URI blobURI, final String resourceGroupName) throws Exception {
+         // Obtain container, storage account, and blob name
+        String storageAccountName = blobURI.getHost().split("\\.")[0];
+        String containerName = PathUtility.getContainerNameFromUri(blobURI, false);
+        String blobName = PathUtility.getBlobNameFromURI(blobURI, false);
+
+        LOGGER.log(Level.INFO, "removeStorageBlob: Removing disk blob {0}, in container {1} of storage account {2}",
+                new Object[]{blobName, containerName, storageAccountName});
+
+        List<StorageAccountKey> storageKeys = azureClient.storageAccounts()
+            .getByGroup(resourceGroupName, storageAccountName)
+            .getKeys();
+        if (!storageKeys.isEmpty()) {
+            String storageAccountKey = storageKeys.get(0).value();
+            CloudStorageAccount account = new CloudStorageAccount(new StorageCredentialsAccountAndKey(storageAccountName, storageAccountKey));
+            CloudBlobClient blobClient = account.createCloudBlobClient();
+            blobClient.getContainerReference(containerName)
+                    .getBlockBlobReference(blobName)
+                    .deleteIfExists();
         }
     }
 

--- a/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
@@ -139,4 +139,12 @@ public class Constants {
     public static final String DEFAULT_RESOURCE_GROUP_PATTERN = "^[a-zA-Z0-9][a-zA-Z\\-_0-9]{0,62}[a-zA-Z0-9]$";
     
     public static final HttpLoggingInterceptor.Level DEFAULT_AZURE_SDK_LOGGING_LEVEL = HttpLoggingInterceptor.Level.NONE;
+    
+    public static final String AZURE_JENKINS_TAG_NAME = "JenkinsManagedTag";
+    
+    public static final String AZURE_JENKINS_TAG_VALUE = "ManagedByAzureVMAgents";
+    
+    public static final String AZURE_RESOURCES_TAG_NAME = "JenkinsResourceTag";
+    
+    public static final long AZURE_DEPLOYMENT_TIMEOUT = 2 * 60 * 60;//in seconds
 }

--- a/src/main/resources/customImageTemplate.json
+++ b/src/main/resources/customImageTemplate.json
@@ -1,8 +1,7 @@
 {
     "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
     "contentVersion": "1.0.0.0",
-    "parameters": {
-    },
+    "parameters": {},
     "variables": {
         "virtualNetworkName": "",
         "subnetName": "",
@@ -11,7 +10,9 @@
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
         "storageAccountContainerName": "[uniqueString(resourceGroup().id, deployment().name)]",
-        "storageAccountType": "Standard_LRS"
+        "storageAccountType": "Standard_LRS",
+        "jenkinsTag": "ManagedByAzureVMAgents",
+        "resourceTag": "AzureJenkinsMasterId"
     },
     "resources": [
         {
@@ -28,6 +29,10 @@
                 "dnsSettings": {
                     "domainNameLabel": "[concat(variables('vmName'), copyIndex())]"
                 }
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
         },
         {
@@ -43,7 +48,8 @@
                 "[concat('Microsoft.Network/publicIPAddresses/', variables('vmName'), copyIndex(), 'IPName')]"
             ],
             "properties": {
-                "ipConfigurations": [{
+                "ipConfigurations": [
+                    {
                         "name": "ipconfig1",
                         "properties": {
                             "privateIPAllocationMethod": "Dynamic",
@@ -54,7 +60,12 @@
                                 "id": "[variables('subnetRef')]"
                             }
                         }
-                    }]
+                    }
+                ]
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
         },
         {
@@ -93,10 +104,17 @@
                     }
                 },
                 "networkProfile": {
-                    "networkInterfaces": [{
+                    "networkInterfaces": [
+                        {
                             "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
-                        }]
+                        }
+                    ]
                 }
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
-        }]
+        }
+    ]
 }

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -2,8 +2,8 @@
     "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "storageAccountKey" : {
-            "type" : "secureString"
+        "storageAccountKey": {
+            "type": "secureString"
         }
     },
     "variables": {
@@ -18,7 +18,9 @@
         "startupScriptURI": "",
         "startupScriptName": "",
         "jenkinsServerURL": "",
-        "clientSecrets": []
+        "clientSecrets": [],
+        "jenkinsTag": "ManagedByAzureVMAgents",
+        "resourceTag": "AzureJenkins"
     },
     "resources": [
         {
@@ -35,6 +37,10 @@
                 "dnsSettings": {
                     "domainNameLabel": "[concat(variables('vmName'), copyIndex())]"
                 }
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
         },
         {
@@ -50,7 +56,8 @@
                 "[concat('Microsoft.Network/publicIPAddresses/', variables('vmName'), copyIndex(), 'IPName')]"
             ],
             "properties": {
-                "ipConfigurations": [{
+                "ipConfigurations": [
+                    {
                         "name": "ipconfig1",
                         "properties": {
                             "privateIPAllocationMethod": "Dynamic",
@@ -61,7 +68,12 @@
                                 "id": "[variables('subnetRef')]"
                             }
                         }
-                    }]
+                    }
+                ]
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
         },
         {
@@ -100,12 +112,14 @@
                     }
                 },
                 "networkProfile": {
-                    "networkInterfaces": [{
+                    "networkInterfaces": [
+                        {
                             "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
-                        }]
+                        }
+                    ]
                 }
             },
-            "resources" : [
+            "resources": [
                 {
                     "type": "extensions",
                     "name": "[concat('customScript', variables('vmName'), copyIndex())]",
@@ -126,12 +140,16 @@
                             "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
                         },
                         "protectedSettings": {
-                            "storageAccountName" : "[variables('storageAccountName')]",
-                            "storageAccountKey" : "[parameters('storageAccountKey')]"
+                            "storageAccountName": "[variables('storageAccountName')]",
+                            "storageAccountKey": "[parameters('storageAccountKey')]"
                         }
                     }
                 }
-            ]
+            ],
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
+            }
         }
     ]
 }

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -1,8 +1,7 @@
 {
     "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
     "contentVersion": "1.0.0.0",
-    "parameters": {
-    },
+    "parameters": {},
     "variables": {
         "virtualNetworkName": "",
         "subnetName": "",
@@ -11,7 +10,9 @@
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
         "storageAccountContainerName": "vhds",
-        "storageAccountType": "Standard_LRS"
+        "storageAccountType": "Standard_LRS",
+        "jenkinsTag": "ManagedByAzureVMAgents",
+        "resourceTag": "AzureJenkins"
     },
     "resources": [
         {
@@ -37,6 +38,10 @@
                 "dnsSettings": {
                     "domainNameLabel": "[concat(variables('vmName'), copyIndex())]"
                 }
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
         },
         {
@@ -52,7 +57,8 @@
                 "[concat('Microsoft.Network/publicIPAddresses/', variables('vmName'), copyIndex(), 'IPName')]"
             ],
             "properties": {
-                "ipConfigurations": [{
+                "ipConfigurations": [
+                    {
                         "name": "ipconfig1",
                         "properties": {
                             "privateIPAllocationMethod": "Dynamic",
@@ -63,7 +69,12 @@
                                 "id": "[variables('subnetRef')]"
                             }
                         }
-                    }]
+                    }
+                ]
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
         },
         {
@@ -105,10 +116,17 @@
                     }
                 },
                 "networkProfile": {
-                    "networkInterfaces": [{
+                    "networkInterfaces": [
+                        {
                             "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
-                        }]
+                        }
+                    ]
                 }
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
-        }]
+        }
+    ]
 }

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -2,8 +2,8 @@
     "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "storageAccountKey" : {
-            "type" : "secureString"
+        "storageAccountKey": {
+            "type": "secureString"
         }
     },
     "variables": {
@@ -18,7 +18,9 @@
         "startupScriptURI": "",
         "startupScriptName": "",
         "jenkinsServerURL": "",
-        "clientSecrets": []
+        "clientSecrets": [],
+        "jenkinsTag": "ManagedByAzureVMAgents",
+        "resourceTag": "AzureJenkins"
     },
     "resources": [
         {
@@ -44,6 +46,10 @@
                 "dnsSettings": {
                     "domainNameLabel": "[concat(variables('vmName'), copyIndex())]"
                 }
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
         },
         {
@@ -59,7 +65,8 @@
                 "[concat('Microsoft.Network/publicIPAddresses/', variables('vmName'), copyIndex(), 'IPName')]"
             ],
             "properties": {
-                "ipConfigurations": [{
+                "ipConfigurations": [
+                    {
                         "name": "ipconfig1",
                         "properties": {
                             "privateIPAllocationMethod": "Dynamic",
@@ -70,7 +77,12 @@
                                 "id": "[variables('subnetRef')]"
                             }
                         }
-                    }]
+                    }
+                ]
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
         },
         {
@@ -112,12 +124,14 @@
                     }
                 },
                 "networkProfile": {
-                    "networkInterfaces": [{
+                    "networkInterfaces": [
+                        {
                             "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
-                        }]
+                        }
+                    ]
                 }
             },
-            "resources" : [
+            "resources": [
                 {
                     "type": "extensions",
                     "name": "[concat('customScript', variables('vmName'), copyIndex())]",
@@ -138,12 +152,16 @@
                             "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
                         },
                         "protectedSettings": {
-                            "storageAccountName" : "[variables('storageAccountName')]",
-                            "storageAccountKey" : "[parameters('storageAccountKey')]"
+                            "storageAccountName": "[variables('storageAccountName')]",
+                            "storageAccountKey": "[parameters('storageAccountKey')]"
                         }
                     }
                 }
-            ]
+            ],
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
+            }
         }
     ]
 }

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMAgentCleanUpTask.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMAgentCleanUpTask.java
@@ -16,14 +16,26 @@
 
 package com.microsoft.azure.vmagent.test;
 
-import com.microsoft.azure.management.resources.Deployment;
+import com.microsoft.azure.PagedList;
+import com.microsoft.azure.management.resources.GenericResource;
+import com.microsoft.azure.management.storage.StorageAccount;
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.ListBlobItem;
 import com.microsoft.azure.vmagent.AzureVMAgentCleanUpTask;
 import com.microsoft.azure.vmagent.AzureVMAgentCleanUpTask.DeploymentRegistrar;
 import com.microsoft.azure.vmagent.AzureVMCloud;
 import com.microsoft.azure.vmagent.AzureVMDeploymentInfo;
+import com.microsoft.azure.vmagent.util.AzureUtil;
+import com.microsoft.azure.vmagent.util.Constants;
+import edu.emory.mathcs.backport.java.util.Arrays;
 import hudson.model.TaskListener;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import static org.mockito.Mockito.*;
@@ -56,6 +68,96 @@ public class ITAzureVMAgentCleanUpTask extends IntegrationTest {
                 Assert.assertNull(customTokenCache.getAzureClient().deployments().getByGroup(testEnv.azureResourceGroup, deploymentInfo.getDeploymentName()));
             } catch (Exception e) {
                 Assert.assertTrue(true);
+            }
+
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, null, e);
+            Assert.assertTrue(e.getMessage(), false);
+        }
+    }
+
+    @Test
+    public void cleanLeakedResourcesRemovesVM() {
+        final String vmName = "tstleak";
+        final String tagName = Constants.AZURE_RESOURCES_TAG_NAME;
+        final AzureUtil.DeploymentTag tagValue = new AzureUtil.DeploymentTag("some_value/123");
+        final AzureUtil.DeploymentTag nonMatchingTagValue1 = new AzureUtil.DeploymentTag("some_value/124");
+        final AzureUtil.DeploymentTag nonMatchingTagValue2 = new AzureUtil.DeploymentTag("some_other_value/9999123");
+        final AzureUtil.DeploymentTag matchingTagValue = new AzureUtil.DeploymentTag("some_value/9999123");
+        final String cloudName = "some_cloud_name";
+        final List<String> emptyValidVMsList = Arrays.asList(new Object[]{});
+        try {
+            AzureVMAgentCleanUpTask cleanUpTask = spy(AzureVMAgentCleanUpTask.class);
+            when(cleanUpTask.getValidVMs(cloudName)).thenReturn(emptyValidVMsList);
+
+            final DeploymentRegistrar deploymentRegistrarMock_nonMatching1 = mock(DeploymentRegistrar.class);
+            when(deploymentRegistrarMock_nonMatching1.getDeploymentTag()).thenReturn(nonMatchingTagValue1);
+            final DeploymentRegistrar deploymentRegistrarMock_nonMatching2 = mock(DeploymentRegistrar.class);
+            when(deploymentRegistrarMock_nonMatching2.getDeploymentTag()).thenReturn(nonMatchingTagValue2);
+            final DeploymentRegistrar deploymentRegistrarMock_matching = mock(DeploymentRegistrar.class);
+            when(deploymentRegistrarMock_matching.getDeploymentTag()).thenReturn(matchingTagValue);
+
+            createAzureVM(vmName, tagName, tagValue.get());
+
+            cleanUpTask.cleanLeakedResources(testEnv.azureResourceGroup, servicePrincipal, cloudName, deploymentRegistrarMock_nonMatching1);
+            Assert.assertNotNull(customTokenCache.getAzureClient().virtualMachines().getByGroup(testEnv.azureResourceGroup, vmName));
+
+            cleanUpTask.cleanLeakedResources(testEnv.azureResourceGroup, servicePrincipal, cloudName, deploymentRegistrarMock_nonMatching2);
+            Assert.assertNotNull(customTokenCache.getAzureClient().virtualMachines().getByGroup(testEnv.azureResourceGroup, vmName));
+
+            cleanUpTask.cleanLeakedResources(testEnv.azureResourceGroup, servicePrincipal, cloudName, deploymentRegistrarMock_matching);
+            Assert.assertNull(customTokenCache.getAzureClient().virtualMachines().getByGroup(testEnv.azureResourceGroup, vmName));
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, null, e);
+            Assert.assertTrue(e.getMessage(), false);
+        }
+    }
+
+    @Test
+    public void cleanLeakedResourcesRemovesDeployedResources() {
+        final AzureUtil.DeploymentTag tagValue = new AzureUtil.DeploymentTag("some_value/123");
+        final AzureUtil.DeploymentTag matchingTagValue = new AzureUtil.DeploymentTag("some_value/9999123");
+        final String cloudName = "some_cloud_name";
+        try {
+
+            final DeploymentRegistrar deploymentRegistrarMock = mock(DeploymentRegistrar.class);
+            when(deploymentRegistrarMock.getDeploymentTag()).thenReturn(tagValue);
+            final DeploymentRegistrar deploymentRegistrarMock_matching = mock(DeploymentRegistrar.class);
+            when(deploymentRegistrarMock_matching.getDeploymentTag()).thenReturn(matchingTagValue);
+
+            final AzureVMDeploymentInfo deployment = createDefaultDeployment(2, deploymentRegistrarMock);
+            final List<String> validVMs = Arrays.asList(new Object[]{deployment.getVmBaseName() + "0"});
+
+            AzureVMAgentCleanUpTask cleanUpTask = spy(AzureVMAgentCleanUpTask.class);
+            when(cleanUpTask.getValidVMs(cloudName)).thenReturn(validVMs);
+
+            cleanUpTask.cleanLeakedResources(testEnv.azureResourceGroup, servicePrincipal, cloudName, deploymentRegistrarMock_matching); //should remove second deployment
+
+            Thread.sleep(20* 1000); // give time for azure to realize that some resources are missing
+            StorageAccount jenkinsStorage = null;
+            PagedList<GenericResource> resources = customTokenCache.getAzureClient().genericResources().listByGroup(testEnv.azureResourceGroup);
+            for (GenericResource resource : resources) {
+                if (StringUtils.containsIgnoreCase(resource.type(), "storageAccounts")) {
+                    jenkinsStorage = customTokenCache.getAzureClient().storageAccounts().getById(resource.id());
+                }
+                if (resource.tags().get(Constants.AZURE_RESOURCES_TAG_NAME) != null &&
+                        matchingTagValue.matches(new AzureUtil.DeploymentTag(resource.tags().get(Constants.AZURE_RESOURCES_TAG_NAME)))) {
+                    String resourceName = resource.name();
+                    String depl = deployment.getVmBaseName() + "0";
+                    Assert.assertTrue("Resource shouldn't exist: " + resourceName +" (vmbase: " + depl + " )",resourceName.contains(depl));
+                }
+            }
+
+            //check the OS disk was removed
+            Assert.assertNotNull("The resource group doesn't have any storage account", jenkinsStorage);
+            final String storageKey = jenkinsStorage.getKeys().get(0).value();
+            CloudStorageAccount account = new CloudStorageAccount(new StorageCredentialsAccountAndKey(jenkinsStorage.name(), storageKey));
+            CloudBlobClient blobClient = account.createCloudBlobClient();
+            CloudBlobContainer container = blobClient.getContainerReference("vhds");
+            Assert.assertTrue(container.exists());
+            for (ListBlobItem blob : container.listBlobs()) {
+                final String u = blob.getUri().toString();
+                Assert.assertTrue("Blobl shouldn't exist: " + u ,u.contains(deployment.getVmBaseName() + "0"));
             }
 
         } catch (Exception e) {

--- a/src/test/java/com/microsoft/azure/vmagent/test/TestDeploymentTag.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/TestDeploymentTag.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.microsoft.azure.vmagent.test;
+
+import com.microsoft.azure.vmagent.util.AzureUtil;
+import org.jvnet.hudson.test.JenkinsRule;
+import jenkins.model.Jenkins;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+
+public class TestDeploymentTag extends AzureUtil.DeploymentTag{
+    @ClassRule public static JenkinsRule j = new JenkinsRule();
+
+    private String jenkinsId = "";
+
+    @Before
+    public void setUp() {
+        jenkinsId = Jenkins.getInstance().getLegacyInstanceId();
+    }
+
+    @Test
+    public void constructAndGet() {
+        final long ts = 1234;
+        Assert.assertEquals(jenkinsId + "/" + Long.toString(ts), tag(ts).get());
+    }
+
+    @Test
+    public void constructFromString() {
+        final long ts = 1234;
+        final String tagStr = jenkinsId + "/" + Long.toString(ts);
+        final AzureUtil.DeploymentTag tag = new AzureUtil.DeploymentTag(tagStr);
+        Assert.assertEquals(tagStr, tag.get());
+    }
+
+    @Test()
+    public void constructFromInvalidString() {
+        Assert.assertEquals(jenkinsId + "/0", (new AzureUtil.DeploymentTag(jenkinsId + "/")).get());
+        Assert.assertEquals(jenkinsId + "/0", (new AzureUtil.DeploymentTag(jenkinsId + "/-1")).get());
+        Assert.assertEquals(jenkinsId + "/0", (new AzureUtil.DeploymentTag(jenkinsId + "/abc")).get());
+        Assert.assertEquals(jenkinsId + "/0", (new AzureUtil.DeploymentTag(jenkinsId + "/123abc")).get());
+        Assert.assertEquals(jenkinsId + "/0", (new AzureUtil.DeploymentTag(jenkinsId + "/-123abc")).get());
+        Assert.assertEquals(jenkinsId + "/0", (new AzureUtil.DeploymentTag(jenkinsId + "/abc123")).get());
+        Assert.assertEquals(jenkinsId + "/0", (new AzureUtil.DeploymentTag(jenkinsId + "//123")).get());
+        Assert.assertEquals(jenkinsId + "/0", (new AzureUtil.DeploymentTag(jenkinsId + "//")).get());
+        Assert.assertEquals(jenkinsId + "/123", (new AzureUtil.DeploymentTag(jenkinsId + "/123/456")).get());
+        Assert.assertEquals("/1", (new AzureUtil.DeploymentTag("/1")).get());
+        Assert.assertEquals("/0", (new AzureUtil.DeploymentTag("/-1")).get());
+        Assert.assertEquals("/0", (new AzureUtil.DeploymentTag("/abc")).get());
+        Assert.assertEquals(jenkinsId + "/0", (new AzureUtil.DeploymentTag(jenkinsId)).get());
+        Assert.assertEquals("/0", (new AzureUtil.DeploymentTag("")).get());
+        Assert.assertEquals("/0", (new AzureUtil.DeploymentTag(null)).get());
+    }
+
+    @Test
+    public void match() {
+        Assert.assertTrue(tag(0).matches(tag(1), 0));
+        Assert.assertTrue(tag(1).matches(tag(0), 0));
+        Assert.assertTrue(tag(15).matches(tag(100), 20));
+        Assert.assertTrue(tag(100).matches(tag(15), 20));
+        Assert.assertTrue(tag(15).matches( new AzureUtil.DeploymentTag(jenkinsId + "/100"), 20));
+        Assert.assertFalse(tag(0).matches(tag(1), 1));
+        Assert.assertFalse(tag(1).matches(tag(0), 1));
+        Assert.assertFalse(tag(100).matches(tag(450), 999));
+        Assert.assertFalse(tag(450).matches(tag(100), 999));
+        Assert.assertFalse(tag(15).matches( new AzureUtil.DeploymentTag("wrong_id/100"), 20));
+        
+    }
+    
+    private AzureUtil.DeploymentTag tag(long timestamp) {
+        return new AzureUtil.DeploymentTag(timestamp){};
+    }
+}


### PR DESCRIPTION
* Tag provisioned resources (the tag is unique per Jenkins master) - except storage accounts (they are used across multiple VMs)
* In the clean up task go through all the Jenkins clouds resource groups and remove all resources that have the tag but we don't keep tabs on (except storage accounts and vNETs)
* Don't do the clean-up while deploying new resources because of race conditions that might end up in pulling the carpet under our own feet (This is the most sensitive code and I have a hunch it can be improved)