### PR TITLE
Fix template verification to take into account the image reference radio button

### DIFF
--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
@@ -44,7 +44,7 @@
         </f:entry>
       </f:radioBlock>
 
-      <f:radioBlock name="imageReferenceType" value="reference" title="${%Marketplace_Image}" checked="${instance.isType('reference')}" help="/plugin/azure-vm-agents/help-imageReference.html" inline="true">
+      <f:radioBlock name="imageReferenceType" value="reference" title="${%Marketplace_Image}" checked="${instance==null || instance.isType('reference')}" help="/plugin/azure-vm-agents/help-imageReference.html" inline="true">
         <f:entry title="${%Image_Publisher}" field="imagePublisher" help="/plugin/azure-vm-agents/help-imageReference.html">
           <f:textbox />
         </f:entry>
@@ -121,6 +121,6 @@
       </div>
     </f:entry>
     <f:validateButton title="${%Verify_Template}" progress="${%Verifying_Template_MSG}" method="verifyConfiguration"
-          with="azureCredentialsId,resourceGroupName,maxVirtualMachinesLimit,deploymentTimeout,templateName,labels,location,virtualMachineSize,storageAccountName,noOfParallelJobs,image,osType,imagePublisher,imageOffer,imageSku,imageVersion,agentLaunchMethod,initScript,credentialsId,virtualNetworkName,subnetName,retentionTimeInMin,jvmOptions" />
+          with="azureCredentialsId,resourceGroupName,maxVirtualMachinesLimit,deploymentTimeout,templateName,labels,location,virtualMachineSize,storageAccountName,noOfParallelJobs,image,osType,imagePublisher,imageOffer,imageSku,imageVersion,agentLaunchMethod,initScript,credentialsId,virtualNetworkName,subnetName,retentionTimeInMin,jvmOptions,imageReferenceType" />
   </table>
 </j:jelly>

--- a/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
@@ -37,6 +37,7 @@ Azure_GC_Template_RT_Null_Or_Empty=Missing retention time.
 Azure_GC_Template_RT_Not_Positive=The retention time must be a positive integer.
 Azure_GC_Template_ImageFamilyOrID_Null_Or_Empty=Missing image family or image ID.
 Azure_GC_Template_ImageURI_Not_Valid=Failed to validate the provided image location.
+Azure_GC_Template_ImageURI_Wrong_Storage_Account=The reference image should be in the same storage account as the one declared in the template.
 Azure_GC_Template_ImageReference_Not_Valid=Failed to validate the provided image reference: {0}
 Azure_GC_Template_ImageURI_Not_In_Same_Account=The image URI is not located in the same storage account as the target storage account for the VM
 Azure_GC_Template_JNLP_Not_Supported=The JNLP launch method is supported only for Windows.

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
@@ -465,31 +465,31 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
     public void verifyVirtualMachineImageTest() {
         try{
             Assert.assertEquals(Constants.OP_SUCCESS, AzureVMManagementServiceDelegate
-                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", "",
+                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", AzureVMAgentTemplate.ImageReferenceType.REFERENCE, "",
                             testEnv.azureImagePublisher, testEnv.azureImageOffer, testEnv.azureImageSku, "latest"));
 
             Assert.assertEquals(Constants.OP_SUCCESS, AzureVMManagementServiceDelegate
-                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", "",
+                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", AzureVMAgentTemplate.ImageReferenceType.REFERENCE, "",
                             testEnv.azureImagePublisher, testEnv.azureImageOffer, testEnv.azureImageSku, ""));
 
             Assert.assertNotEquals(Constants.OP_SUCCESS, AzureVMManagementServiceDelegate
-                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", "",
+                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", AzureVMAgentTemplate.ImageReferenceType.REFERENCE, "",
                             testEnv.azureImagePublisher, testEnv.azureImageOffer, testEnv.azureImageSku, "wrong_version"));
 
             Assert.assertNotEquals(Constants.OP_SUCCESS, AzureVMManagementServiceDelegate
-                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation +"wrong", "", "",
+                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation +"wrong", "", AzureVMAgentTemplate.ImageReferenceType.REFERENCE, "",
                             testEnv.azureImagePublisher, testEnv.azureImageOffer, testEnv.azureImageSku, ""));
 
             Assert.assertNotEquals(Constants.OP_SUCCESS, AzureVMManagementServiceDelegate
-                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", "",
+                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", AzureVMAgentTemplate.ImageReferenceType.REFERENCE, "",
                             testEnv.azureImagePublisher + "wrong", testEnv.azureImageOffer, testEnv.azureImageSku, "latest"));
 
             Assert.assertNotEquals(Constants.OP_SUCCESS, AzureVMManagementServiceDelegate
-                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", "",
+                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", AzureVMAgentTemplate.ImageReferenceType.REFERENCE, "",
                             testEnv.azureImagePublisher, testEnv.azureImageOffer + "wrong", testEnv.azureImageSku, ""));
 
             Assert.assertNotEquals(Constants.OP_SUCCESS, AzureVMManagementServiceDelegate
-                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", "",
+                    .verifyVirtualMachineImage(servicePrincipal, testEnv.azureLocation, "", AzureVMAgentTemplate.ImageReferenceType.REFERENCE, "",
                             testEnv.azureImagePublisher, testEnv.azureImageOffer, testEnv.azureImageSku + "wrong", "latest"));
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, null, e);


### PR DESCRIPTION
Once this PR makes it to Jenkins core we'll be able to detect which radio button is selected and we can verify the right image in the template:
https://github.com/jenkinsci/jenkins/pull/2734

The fix will only work for newer Jenkins builds. For old ones the logic should be unchanged (if image field is not empty then we verify for the custom image)