### PR TITLE
Update the storage account API version in the deployment JSON so it matches with the SDK API version

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -52,6 +52,7 @@ import com.microsoft.azure.management.compute.VirtualMachinePublisher;
 import com.microsoft.azure.management.compute.VirtualMachineSku;
 import com.microsoft.azure.management.network.Network;
 import com.microsoft.azure.management.resources.DeploymentMode;
+import com.microsoft.azure.management.storage.SkuName;
 import com.microsoft.azure.management.storage.StorageAccountKey;
 import com.microsoft.azure.vmagent.retry.ExponentialRetryStrategy;
 import com.microsoft.azure.vmagent.retry.NoRetryStrategy;
@@ -351,6 +352,7 @@ public class AzureVMManagementServiceDelegate {
             azureClient.storageAccounts().define(targetStorageAccount)
                     .withRegion(location)
                     .withExistingResourceGroup(resourceGroupName)
+                    .withSku(SkuName.STANDARD_LRS)
                     .create();
         } catch (Exception e) {
             LOGGER.log(Level.INFO, e.getMessage());

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -17,10 +17,10 @@
         {
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
-            "apiVersion": "2015-05-01-preview",
+            "apiVersion": "2016-01-01",
             "location": "[variables('location')]",
-            "properties": {
-                "accountType": "[variables('storageAccountType')]"
+            "sku": {
+                "name": "[variables('storageAccountType')]"
             }
         },
         {

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -24,10 +24,10 @@
         {
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
-            "apiVersion": "2015-05-01-preview",
+            "apiVersion": "2016-01-01",
             "location": "[variables('location')]",
-            "properties": {
-                "accountType": "[variables('storageAccountType')]"
+            "sku": {
+                "name": "[variables('storageAccountType')]"
             }
         },
         {

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
@@ -519,4 +519,22 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
             Assert.assertTrue(e.getMessage(), false);
         }
     }
+
+    @Test
+    public void deploymentWorksIfStorageAccountIsCreatedBefore() {
+        /*
+        uploadCustomScript creates the storage account if it's not available.
+        The SDK will always create it using the latest API version.
+        The deployment has an hardcoded API version that might be lower than the one in the SDK, thus failing the deployment.
+        This test makes sure the deployment JSON is up to date API version-wise
+        */
+        try {
+            final String uploadFileName = UUID.randomUUID().toString() + ".txt";
+            uploadCustomScript(uploadFileName, UUID.randomUUID().toString());
+            createDefaultDeployment(1, null);
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, null, e);
+            Assert.assertTrue(e.getMessage(), false);
+        }
+    }
 }


### PR DESCRIPTION
Fixed an issue introduced with the Azure SDK update: if the storage account is created first (through uploadCustomScript) then the deployment would have failed because the API versions didn't match.
I've also added a test to catch this in the future when we'll update the SDK version.