### PR TITLE
small fixes on bugs brought in with the Azure SDK update

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -27,6 +27,7 @@ import com.microsoft.azure.management.compute.OperatingSystemTypes;
 import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.resources.Deployment;
 import com.microsoft.azure.management.resources.DeploymentOperation;
+import com.microsoft.azure.management.resources.TargetResource;
 import com.microsoft.azure.util.AzureCredentials;
 import com.microsoft.azure.vmagent.remote.AzureVMAgentSSHLauncher;
 import com.microsoft.azure.vmagent.util.AzureUtil;
@@ -396,6 +397,9 @@ public class AzureVMCloud extends Cloud {
             for (Deployment dep : deployments) {
                 PagedList<DeploymentOperation> ops = dep.deploymentOperations().list();
                 for (DeploymentOperation op : ops) {
+                    if (op.targetResource() == null) {
+                        continue;
+                    }
                     final String resource = op.targetResource().resourceName();
                     final String type = op.targetResource().resourceType();
                     final String state = op.provisioningState();

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -593,8 +593,14 @@ public class AzureVMManagementServiceDelegate {
                     }
 
                     for (String location: resourceType.locations()) {
-                        if (!azureClient.virtualMachines().sizes().listByRegion(location).isEmpty()) {
-                            regions.add(location);
+                        if (!regions.contains(location)) {
+                            try {
+                                if (!azureClient.virtualMachines().sizes().listByRegion(location).isEmpty()) {
+                                    regions.add(location);
+                                }
+                            } catch (Exception e){
+                                //some of the provider regions might not be valid for other API calls. The SDK call will throw an exception instead of returning an emtpy list
+                            }
                         }
                     }
 


### PR DESCRIPTION
* Some subscriptions have some weird regions that cause the SDK to throw an exception. 
    Making sure getVirtualMachineLocations catches them and provides a correct list of regions
* The new SDK returns DeploymentOperation objects that don't have a targetResource object associated with them.
    We're skipping those objects, otherwise we can't provision agents from deployments with more than 1 VM