### PR TITLE
Be less restrictive with the OAuth Token endpoint format

### DIFF
--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -182,15 +182,15 @@ public class AzureCredentials extends BaseStandardCredentials {
 
         private static String getTenantFromTokenEndpoint(String oauth2TokenEndpoint)
         {
-            if(!oauth2TokenEndpoint.matches("[a-z:/\\.]*/[a-z0-9\\-]*/oauth2/token$")) {
+            if(!oauth2TokenEndpoint.matches("https://[a-zA-Z0-9\\.]*/[a-z0-9\\-]*/?.*$")) {
                 return "";
             } else {
                 final String[] parts = oauth2TokenEndpoint.split("/");
-                for (int i = parts.length - 1; i > 0; i--) {
-                    if (parts[i].equalsIgnoreCase("oauth2") && i > 0)
-                        return parts[i-1];
+                if (parts.length < 4) {
+                    return "";
+                } else {
+                    return parts[3];
                 }
-                return "";
             }
         }
 


### PR DESCRIPTION
As Olivier points out [here](https://github.com/jenkinsci/azure-vm-agents-plugin/commit/47a57a498efde2fc95a4abd63a45ec68b7f64f36#commitcomment-20805286) the token endpoint needs to be less restrictive.
I'm now allowing any URL in this format: 
> https://[a-zA-Z0-9\\.]*/[a-z0-9\\-]*/?.*$
I hope it will cover all cases, but if I compute the wrong token the verification will fail later and the user will need to update

