### PR TITLE
fix bug endpoints are't picked for verification

### DIFF
--- a/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
+++ b/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
@@ -32,5 +32,5 @@
 
     <st:include page="id-and-description" class="${descriptor.clazz}"/>
     <f:validateButton title="${%Verify Configuration}" progress="${%Verifying}" method="verifyConfiguration"
-          with="subscriptionId,clientId,clientSecret,oauth2TokenEndpoint,serviceManagementURL" />
+          with="subscriptionId,clientId,clientSecret,oauth2TokenEndpoint,serviceManagementURL,authenticationEndpoint,resourceManagerEndpoint,graphEndpoint" />
 </j:jelly>


### PR DESCRIPTION
Fix the problem that , the inputs of authenticationEndpoint,resourceManagerEndpoint and graphEndpoint don't get picked up when clicking verification button in credential page