### PR TITLE
Delete empty containers from cleaned deployments of custom images

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -65,6 +65,7 @@ import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
+import com.microsoft.azure.storage.blob.ListBlobItem;
 import com.microsoft.azure.util.AzureCredentials;
 import com.microsoft.azure.util.AzureCredentials.ServicePrincipal;
 import com.microsoft.azure.vmagent.util.AzureUtil;
@@ -901,6 +902,16 @@ public class AzureVMManagementServiceDelegate {
             blobClient.getContainerReference(containerName)
                     .getBlockBlobReference(blobName)
                     .deleteIfExists();
+
+            if (containerName.startsWith("jnk")) {
+                Iterable<ListBlobItem> blobs = blobClient.getContainerReference(containerName).listBlobs();
+                if (blobs.iterator().hasNext()) { // the container is not empty
+                    return;
+                }
+                // the container is empty and we should delete it
+                LOGGER.log(Level.INFO, "removeStorageBlob: Removing empty container ", containerName);
+                blobClient.getContainerReference(containerName).delete();
+            }
         }
     }
 

--- a/src/main/resources/customImageTemplate.json
+++ b/src/main/resources/customImageTemplate.json
@@ -9,7 +9,7 @@
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
-        "storageAccountContainerName": "[uniqueString(resourceGroup().id, deployment().name)]",
+        "storageAccountContainerName": "[concat('jnk',uniqueString(resourceGroup().id, deployment().name))]",
         "storageAccountType": "Standard_LRS",
         "jenkinsTag": "ManagedByAzureVMAgents",
         "resourceTag": "AzureJenkinsMasterId"

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -13,7 +13,7 @@
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
-        "storageAccountContainerName": "[uniqueString(resourceGroup().id, deployment().name)]",
+        "storageAccountContainerName": "[concat('jnk',uniqueString(resourceGroup().id, deployment().name))]",
         "storageAccountType": "Standard_LRS",
         "startupScriptURI": "",
         "startupScriptName": "",


### PR DESCRIPTION
* I've added the 'jnk' prefix for the custom vhd container
* When removing the vhd I check if the container has the 'jnk' prefix and if it's empty. If so I also remove the container.
