### PR TITLE
Upgrade the Azure SDK to beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <azuresdk.version>1.0.0-beta4.1</azuresdk.version>
+    <azuresdk.version>1.0.0-beta5</azuresdk.version>
     <azure-storage.version>4.4.0</azure-storage.version>
     <jenkins.version>1.653</jenkins.version>
     <java.level>7</java.level>
@@ -163,6 +163,16 @@
     <repository>
       <id>repo.jenkins-ci.org</id>
       <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+    <repository>
+        <id>com.springsource.repository.bundles.release</id>
+        <name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
+        <url>http://repository.springsource.com/maven/bundles/release</url>
+    </repository>
+    <repository>
+        <id>com.springsource.repository.bundles.external</id>
+        <name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
+        <url>http://repository.springsource.com/maven/bundles/external</url>
     </repository>
   </repositories>
 

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -302,7 +302,7 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
 
                     URI osDiskURI = null;
                     if (StringUtils.containsIgnoreCase(resource.type(), "virtualMachine")) {
-                        osDiskURI = new URI(azureClient.virtualMachines().getById(resource.id()).osDiskVhdUri());
+                        osDiskURI = new URI(azureClient.virtualMachines().getById(resource.id()).osUnmanagedDiskVhdUri());
                     }
 
                     LOGGER.log(Level.INFO, "cleanLeakedResources: deleting {0} from resource group {1}", new Object[]{resource.name(), resourceGroup});

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -846,7 +846,7 @@ public class AzureVMManagementServiceDelegate {
                     final Azure azureClient = TokenCache.getInstance(servicePrincipal).getAzureClient();
                     List<URI> diskUrisToRemove = new ArrayList<>();
                     // Mark OS disk for removal
-                    diskUrisToRemove.add(new URI(azureClient.virtualMachines().getByGroup(resourceGroupName, vmName).osDiskVhdUri()));
+                    diskUrisToRemove.add(new URI(azureClient.virtualMachines().getByGroup(resourceGroupName, vmName).osUnmanagedDiskVhdUri()));
                     // TODO: Remove data disks or add option to do so?
 
                     // Remove the VM

--- a/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
@@ -15,6 +15,7 @@
  */
 package com.microsoft.azure.vmagent.util;
 
+import com.microsoft.rest.LogLevel;
 import okhttp3.logging.HttpLoggingInterceptor;
 
 public class Constants {
@@ -138,7 +139,7 @@ public class Constants {
     
     public static final String DEFAULT_RESOURCE_GROUP_PATTERN = "^[a-zA-Z0-9][a-zA-Z\\-_0-9]{0,62}[a-zA-Z0-9]$";
     
-    public static final HttpLoggingInterceptor.Level DEFAULT_AZURE_SDK_LOGGING_LEVEL = HttpLoggingInterceptor.Level.NONE;
+    public static final LogLevel DEFAULT_AZURE_SDK_LOGGING_LEVEL = LogLevel.NONE;
     
     public static final String AZURE_JENKINS_TAG_NAME = "JenkinsManagedTag";
     

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
@@ -327,7 +327,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
         try {
             final String vmName = "vmterminate";
             VirtualMachine vm = createAzureVM(vmName);
-            final URI osDiskStorageAccount = new URI(vm.osDiskVhdUri());
+            final URI osDiskStorageAccount = new URI(vm.osUnmanagedDiskVhdUri());
             Assert.assertTrue(blobExists(osDiskStorageAccount));
 
             ExecutionEngine executionEngineMock = mock(ExecutionEngine.class);

--- a/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
@@ -151,7 +151,7 @@ public class IntegrationTest {
         try {
             customTokenCache.getAzureClient().resourceGroups().deleteByName(testEnv.azureResourceGroup);
         } catch (CloudException e) {
-            if (e.getResponse().code() != 404) {
+            if (e.response().code() != 404) {
                 LOGGER.log(Level.SEVERE, null, e);
             }
         }
@@ -315,6 +315,7 @@ public class IntegrationTest {
                 .withPopularLinuxImage(KnownLinuxVirtualMachineImage.UBUNTU_SERVER_14_04_LTS)
                 .withRootUsername(TestEnvironment.GenerateRandomString(8))
                 .withRootPassword(TestEnvironment.GenerateRandomString(16) + "AA@@12345") //don't try this at home
+                .withUnmanagedDisks()
                 .withTag(Constants.AZURE_JENKINS_TAG_NAME, Constants.AZURE_JENKINS_TAG_VALUE)
                 .withTag(tagName, tagValue)
                 .create();


### PR DESCRIPTION
Azure beta4 SDK has an issue with listing the deployments in certain resource groups (I suspect it has to do with the number of deployments) and because of that the vm agents is not able to provision agents in those RGs.
beta5 seems not to have this issue.