### PR TITLE
Provide default vm size list when the region was not yet selected [FIXED JENKINS-42853]

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -518,10 +518,11 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
             ListBoxModel model = new ListBoxModel();
             List<String> vmSizes = AzureVMManagementServiceDelegate.getVMSizes(servicePrincipal, location);
 
-            for (String vmSize : vmSizes) {
-                model.add(vmSize);
+            if (vmSizes != null) {
+                for (String vmSize : vmSizes) {
+                    model.add(vmSize);
+                }
             }
-
             return model;
         }
 

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -115,6 +115,8 @@ public class AzureVMManagementServiceDelegate {
 
     private static final Set<String> AVAILABLE_LOCATIONS_CHINA = getAvailableLocationsChina();
     
+    private static final List<String> DEFAULT_VM_SIZES = Arrays.asList(new String[]{"Standard_A0","Standard_A1","Standard_A2","Standard_A3","Standard_A5","Standard_A4","Standard_A6","Standard_A7","Basic_A0","Basic_A1","Basic_A2","Basic_A3","Basic_A4","Standard_DS1_v2","Standard_DS2_v2","Standard_DS3_v2","Standard_DS4_v2","Standard_DS5_v2","Standard_DS11_v2","Standard_DS12_v2","Standard_DS13_v2","Standard_DS14_v2","Standard_DS15_v2","Standard_DS1","Standard_DS2","Standard_DS3","Standard_DS4","Standard_DS11","Standard_DS12","Standard_DS13","Standard_DS14","Standard_F1s","Standard_F2s","Standard_F4s","Standard_F8s","Standard_F16s","Standard_D1","Standard_D2","Standard_D3","Standard_D4","Standard_D11","Standard_D12","Standard_D13","Standard_D14","Standard_A1_v2","Standard_A2m_v2","Standard_A2_v2","Standard_A4m_v2","Standard_A4_v2","Standard_A8m_v2","Standard_A8_v2","Standard_D1_v2","Standard_D2_v2","Standard_D3_v2","Standard_D4_v2","Standard_D5_v2","Standard_D11_v2","Standard_D12_v2","Standard_D13_v2","Standard_D14_v2","Standard_D15_v2","Standard_F1","Standard_F2","Standard_F4","Standard_F8","Standard_F16"});
+    
     /**
      * Creates a new deployment of VMs based on the provided template
      *
@@ -612,6 +614,10 @@ public class AzureVMManagementServiceDelegate {
      * @return List of VM sizes
      */
     public static List<String> getVMSizes(AzureCredentials.ServicePrincipal servicePrincipal, final String location) {
+        if (location == null || location.isEmpty()) {
+            //if the location is not available we'll just return a default list with some of the most common VM sizes
+            return DEFAULT_VM_SIZES;
+        }
         try {
             List<String> ret = new ArrayList<>();
             final Azure azureClient = TokenCache.getInstance(servicePrincipal).getAzureClient();


### PR DESCRIPTION
The doFillXYZ methods are called in parallel so doFillVirtualMachineSizeItems will fail because the location parameter is empty.
I've implemented an easy fix where the plugin just returns a static list of most common VM sizes when the location is unavailable.
A better fix would be to wait in doFillVirtualMachineSizeItems until the available regions have been fetched, but the implementation looks to be fairly complicated involving several layers of synchronization (we can talk offline) and the final result won't be that different from the easy fix.