### PR TITLE
agentWorkspace should not be hidden in an Advanced block

### DIFF
--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
@@ -13,6 +13,11 @@
                 <f:textbox/>
             </f:entry>
 
+            <f:entry title="${%Agent_Workspace}" field="agentWorkspace"
+                     help="/plugin/azure-vm-agents/help-agentWorkspace.html">
+                <f:textbox/>
+            </f:entry>
+
             <f:entry title="${%Labels}" field="labels" help="/plugin/azure-vm-agents/help-labels.html">
                 <f:textbox/>
             </f:entry>
@@ -125,11 +130,6 @@
                 <f:textbox/>
             </f:entry>
 
-
-            <f:entry title="${%Agent_Workspace}" field="agentWorkspace"
-                     help="/plugin/azure-vm-agents/help-agentWorkspace.html">
-                <f:textbox/>
-            </f:entry>
 
             <f:entry title="${%JVM_Options}" field="jvmOptions" help="/plugin/azure-vm-agents/help-jvmOptions.html">
                 <f:textbox/>


### PR DESCRIPTION
Cf. [core UI for static agents](https://github.com/jenkinsci/jenkins/blob/4eb9d8ab6d41883ab764b705d4635c49336e60b7/core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly#L39-L41) and [discussion](https://issues.jenkins-ci.org/browse/INFRA-1141?focusedCommentId=298049&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-298049) of a problem apparently due to an administrator neglecting to fill in this important field.

@reviewbybees esp. @rtyler