### PR TITLE
Add an option to allow different resource group for custom virtual network

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -1,12 +1,12 @@
 /*
  Copyright 2016 Microsoft, Inc.
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -123,6 +123,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
 
     private String virtualNetworkName;
 
+    private String virtualNetworkResourceGroupName;
+
     private String subnetName;
 
     private boolean usePrivateIP;
@@ -169,6 +171,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
             final String initScript,
             final String credentialsId,
             final String virtualNetworkName,
+            final String virtualNetworkResourceGroupName,
             final String subnetName,
             final boolean usePrivateIP,
             final String nsgName,
@@ -207,6 +210,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
         this.agentLaunchMethod = agentLaunchMethod;
         this.credentialsId = credentialsId;
         this.virtualNetworkName = virtualNetworkName;
+        this.virtualNetworkResourceGroupName = virtualNetworkResourceGroupName;
         this.subnetName = subnetName;
         this.usePrivateIP = usePrivateIP;
         this.nsgName = nsgName;
@@ -333,6 +337,10 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
         this.virtualNetworkName = virtualNetworkName;
     }
 
+    public String getVirtualNetworkResourceGroupName() {
+        return this.virtualNetworkResourceGroupName;
+    }
+
     public String getSubnetName() {
         return subnetName;
     }
@@ -340,7 +348,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
     public void setSubnetName(String subnetName) {
         this.subnetName = subnetName;
     }
-    
+
     public boolean getUsePrivateIP() {
         return usePrivateIP;
     }
@@ -369,7 +377,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
         azureCloud = cloud;
         if (StringUtils.isBlank(storageAccountName)) {
             storageAccountName = AzureVMAgentTemplate.generateUniqueStorageAccountName(azureCloud.getResourceGroupName(), azureCloud.getServicePrincipal());
-            
+
         }
     }
 
@@ -508,6 +516,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                 initScript,
                 credentialsId,
                 virtualNetworkName,
+                virtualNetworkResourceGroupName,
                 subnetName,
                 retentionTimeInMin + "",
                 jvmOptions,
@@ -571,7 +580,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
 
             return model;
         }
-        
+
         public ListBoxModel doFillUsageModeItems() throws IOException, ServletException {
             ListBoxModel model = new ListBoxModel();
             for(Node.Mode m : hudson.Functions.getNodeModes()) {
@@ -710,6 +719,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                 @QueryParameter String initScript,
                 @QueryParameter String credentialsId,
                 @QueryParameter String virtualNetworkName,
+                @QueryParameter String virtualNetworkResourceGroupName,
                 @QueryParameter String subnetName,
                 @QueryParameter boolean usePrivateIP,
                 @QueryParameter String nsgName,
@@ -753,11 +763,12 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                             + "initScript: {18};\n\t"
                             + "credentialsId: {19};\n\t"
                             + "virtualNetworkName: {20};\n\t"
-                            + "subnetName: {21};\n\t"
-                            + "privateIP: {22};\n\t"
-                            + "nsgName: {23};\n\t"
-                            + "retentionTimeInMin: {24};\n\t"
-                            + "jvmOptions: {25};",
+                            + "virtualNetworkResourceGroupName: {21};\n\t"
+                            + "subnetName: {22};\n\t"
+                            + "privateIP: {23};\n\t"
+                            + "nsgName: {24};\n\t"
+                            + "retentionTimeInMin: {25};\n\t"
+                            + "jvmOptions: {26};",
                     new Object[]{
                             servicePrincipal.getSubscriptionId(),
                             (StringUtils.isNotBlank(servicePrincipal.getClientId()) ? "********" : null),
@@ -780,6 +791,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                             initScript,
                             credentialsId,
                             virtualNetworkName,
+                            virtualNetworkResourceGroupName,
                             subnetName,
                             usePrivateIP,
                             nsgName,
@@ -787,8 +799,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                             jvmOptions});
 
             // First validate the subscription info.  If it is not correct,
-            // then we can't validate the 
-            String result = AzureVMManagementServiceDelegate.verifyConfiguration(servicePrincipal, resourceGroupName, 
+            // then we can't validate the
+            String result = AzureVMManagementServiceDelegate.verifyConfiguration(servicePrincipal, resourceGroupName,
                     maxVirtualMachinesLimit, deploymentTimeout);
             if (!result.equals(Constants.OP_SUCCESS)) {
                 return FormValidation.error(result);
@@ -813,6 +825,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
                     initScript,
                     credentialsId,
                     virtualNetworkName,
+                    virtualNetworkResourceGroupName,
                     subnetName,
                     retentionTimeInMin,
                     jvmOptions,

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
@@ -117,6 +117,11 @@
                 <f:textbox/>
             </f:entry>
 
+            <f:entry title="${%VirtualNetworkResourceGroup_Name}" field="virtualNetworkResourceGroupName"
+                     help="/plugin/azure-vm-agents/help-virtualNetworkResourceGroupName.html">
+                <f:textbox/>
+            </f:entry>
+
             <f:entry title="${%Subnet_Name}" field="subnetName" help="/plugin/azure-vm-agents/help-subnetName.html">
                 <f:textbox/>
             </f:entry>
@@ -156,6 +161,6 @@
             </div>
         </f:entry>
         <f:validateButton title="${%Verify_Template}" progress="${%Verifying_Template_MSG}" method="verifyConfiguration"
-                          with="azureCredentialsId,resourceGroupName,maxVirtualMachinesLimit,deploymentTimeout,templateName,labels,location,virtualMachineSize,storageAccountName,noOfParallelJobs,image,osType,imagePublisher,imageOffer,imageSku,imageVersion,agentLaunchMethod,initScript,credentialsId,virtualNetworkName,subnetName,usePrivateIP,nsgName,retentionTimeInMin,jvmOptions,imageReferenceType"/>
+                          with="azureCredentialsId,resourceGroupName,maxVirtualMachinesLimit,deploymentTimeout,templateName,labels,location,virtualMachineSize,storageAccountName,noOfParallelJobs,image,osType,imagePublisher,imageOffer,imageSku,imageVersion,agentLaunchMethod,initScript,credentialsId,virtualNetworkName,virtualNetworkResourceGroupName,subnetName,usePrivateIP,nsgName,retentionTimeInMin,jvmOptions,imageReferenceType"/>
     </table>
 </j:jelly>

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
@@ -40,6 +40,7 @@ Delete_Template=Delete Template
 Verify_Template=Verify Template
 Verifying_Template_MSG=Verifying Template, this may take time. Please wait...
 VirtualNetwork_Name=Virtual Network Name
+VirtualNetworkResourceGroup_Name=Virtual Network Resource Group Name
 Subnet_Name=Subnet Name
 shutdownOnIdle=Shutdown Only (Do Not Delete) After Retention Time
 Use_Private_Ip=Make VM agent IP private

--- a/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
@@ -45,7 +45,7 @@ Azure_GC_Template_UN_Null_Or_Empty=Missing admin user name.
 Azure_GC_Template_PWD_Null_Or_Empty=Missing admin password.
 Azure_GC_Template_PWD_Not_Valid=Required: Not a valid password. The password length must be between 8 and 123 characters. It also needs to have at least one digit, one lowercase, one uppercase letter and one special character ( @#$%^&*-_!+=[]'{}'|\\:`,.?/~\"();\' ).
 Azure_GC_Template_VirtualNetwork_Null_Or_Empty=Missing virtual network name.
-Azure_GC_Template_VirtualNetwork_NotFound=The virtual network {0} does not exist in this subscription.
+Azure_GC_Template_VirtualNetwork_NotFound=The virtual network {0} does not exist in the resource group {1} in this subscription.
 Azure_GC_Template_subnet_Empty=The subnet name cannot be empty
 Azure_GC_Template_subnet_NotFound=The subnet {0} does not belong to the specified virtual network.
 

--- a/src/main/resources/customImageTemplate.json
+++ b/src/main/resources/customImageTemplate.json
@@ -4,10 +4,11 @@
     "parameters": {},
     "variables": {
         "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
         "subnetName": "",
         "nsgName": "",
         "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
         "storageAccountContainerName": "[concat('jnk',uniqueString(resourceGroup().id, deployment().name))]",

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -8,10 +8,11 @@
     },
     "variables": {
         "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
         "subnetName": "",
         "nsgName": "",
         "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
         "storageAccountContainerName": "[concat('jnk',uniqueString(resourceGroup().id, deployment().name))]",

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -4,10 +4,11 @@
     "parameters": {},
     "variables": {
         "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
         "subnetName": "",
         "nsgName": "",
         "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
         "storageAccountContainerName": "vhds",

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -8,10 +8,11 @@
     },
     "variables": {
         "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
         "subnetName": "",
         "nsgName": "",
         "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
         "publicIPAddressType": "Dynamic",
         "storageAccountContainerName": "vhds",

--- a/src/main/webapp/help-virtualNetworkResourceGroupName.html
+++ b/src/main/webapp/help-virtualNetworkResourceGroupName.html
@@ -1,0 +1,1 @@
+The name of an existing resource group in Azure where the virtual network is located. If left blank, the resourceGroup as specified in the General Configuration section of the template is used.

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
@@ -191,7 +191,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
             Assert.assertNotNull("The deployed Network interface doesn't exist", actualNetIface);
             Assert.assertTrue("The deployed VM doesn't have a private IP", privateIP != null && !privateIP.isEmpty());
             Assert.assertNull("The deployed VM shouldn't have a public IP", actualIP);
-            
+
 
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, null, e);
@@ -653,38 +653,39 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
     public void verifyVirtualNetworkTest() {
         try{
             final String vnetName = "jenkinsarm-vnet";
+            final String vnetResourceGroup = "";
             final String subnetName = "jenkinsarm-snet";
             createDefaultDeployment(1, null);
 
            Assert.assertEquals(Constants.OP_SUCCESS,
                     AzureVMManagementServiceDelegate
-                            .verifyVirtualNetwork(servicePrincipal, vnetName, subnetName, false, testEnv.azureResourceGroup));
+                            .verifyVirtualNetwork(servicePrincipal, vnetName, vnetResourceGroup, subnetName, false, testEnv.azureResourceGroup));
 
             final String wrongVnet = vnetName+"wrong";
-            Assert.assertEquals(Messages.Azure_GC_Template_VirtualNetwork_NotFound(wrongVnet),
+            Assert.assertEquals(Messages.Azure_GC_Template_VirtualNetwork_NotFound(wrongVnet, testEnv.azureResourceGroup),
                     AzureVMManagementServiceDelegate
-                            .verifyVirtualNetwork(servicePrincipal, wrongVnet, subnetName, false, testEnv.azureResourceGroup));
+                            .verifyVirtualNetwork(servicePrincipal, wrongVnet, vnetResourceGroup, subnetName, false, testEnv.azureResourceGroup));
 
             final String wrongSnet = subnetName+"wrong";
             Assert.assertEquals(Messages.Azure_GC_Template_subnet_NotFound(wrongSnet),
                     AzureVMManagementServiceDelegate
-                            .verifyVirtualNetwork(servicePrincipal, vnetName, wrongSnet, false, testEnv.azureResourceGroup));
-            
-            Assert.assertEquals(Messages.Azure_GC_Template_VirtualNetwork_Null_Or_Empty(),
-                   AzureVMManagementServiceDelegate
-                           .verifyVirtualNetwork(servicePrincipal, "", subnetName, false, testEnv.azureResourceGroup));
-            
-            Assert.assertEquals(Constants.OP_SUCCESS,
-                   AzureVMManagementServiceDelegate
-                           .verifyVirtualNetwork(servicePrincipal, "", "", false, testEnv.azureResourceGroup));
+                            .verifyVirtualNetwork(servicePrincipal, vnetName, vnetResourceGroup, wrongSnet, false, testEnv.azureResourceGroup));
 
             Assert.assertEquals(Messages.Azure_GC_Template_VirtualNetwork_Null_Or_Empty(),
                    AzureVMManagementServiceDelegate
-                           .verifyVirtualNetwork(servicePrincipal, "", "", true, testEnv.azureResourceGroup));
-            
+                           .verifyVirtualNetwork(servicePrincipal, "", vnetResourceGroup, subnetName, false, testEnv.azureResourceGroup));
+
+            Assert.assertEquals(Constants.OP_SUCCESS,
+                   AzureVMManagementServiceDelegate
+                           .verifyVirtualNetwork(servicePrincipal, "", vnetResourceGroup, "", false, testEnv.azureResourceGroup));
+
+            Assert.assertEquals(Messages.Azure_GC_Template_VirtualNetwork_Null_Or_Empty(),
+                   AzureVMManagementServiceDelegate
+                           .verifyVirtualNetwork(servicePrincipal, "", vnetResourceGroup, "", true, testEnv.azureResourceGroup));
+
             Assert.assertEquals(Messages.Azure_GC_Template_subnet_Empty(),
                    AzureVMManagementServiceDelegate
-                           .verifyVirtualNetwork(servicePrincipal, vnetName, "", false, testEnv.azureResourceGroup));
+                           .verifyVirtualNetwork(servicePrincipal, vnetName, vnetResourceGroup,"", false, testEnv.azureResourceGroup));
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, null, e);
             Assert.assertTrue(e.getMessage(), false);
@@ -789,7 +790,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
             Assert.assertTrue(e.getMessage(), false);
         }
     }
-    
+
     @Test
     //Add Test for global first, will add test for mooncake later
     public void getBlobEndpointSuffixForArmTemplateForGlobal(){
@@ -801,7 +802,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
             .create();
             StorageAccount storageAccount = customTokenCache.getAzureClient().storageAccounts().getByGroup(testEnv.azureResourceGroup, testEnv.azureStorageAccountName);
             String endSuffix = AzureVMManagementServiceDelegate.getBlobEndpointSuffixForTemplate(storageAccount);
-            Assert.assertEquals(endSuffix, testEnv.blobEndpointSuffixForTemplate.get(TestEnvironment.AZUREPUBLIC));            
+            Assert.assertEquals(endSuffix, testEnv.blobEndpointSuffixForTemplate.get(TestEnvironment.AZUREPUBLIC));
         } catch (Exception e){
             LOGGER.log(Level.SEVERE, null, e);
             Assert.assertTrue(e.getMessage(), false);
@@ -828,7 +829,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
             Assert.assertTrue(e.getMessage(), false);
         }
     }
-    
+
     @Test
     //Add Test for global first, will add test for mooncake later
     public void getBlobEndpointSuffixForCloudStorageAccountForGlobal() {


### PR DESCRIPTION
This patch is based on #11 and has been rebased onto the latest master branch.

As for the default value issue mentioned in #11, I think it's ok to leave the field blank by default since `AzureVMManagementServiceDelegate.createDeployment` has already handled the blank condition properly. 