### PR TITLE
enable multiple cloud profile with the same subscription Id

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -259,6 +259,9 @@ public class AzureVMAgent extends AbstractCloudSlave {
         return cleanUpReason;
     }
 
+    /**
+     * @param cleanUpReason
+     */
     private void setCleanUpAction(CleanUpAction cleanUpAction) {
         // Translate a default cleanup action into what we want for a particular
         // node

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -259,9 +259,6 @@ public class AzureVMAgent extends AbstractCloudSlave {
         return cleanUpReason;
     }
 
-    /**
-     * @param cleanUpReason
-     */
     private void setCleanUpAction(CleanUpAction cleanUpAction) {
         // Translate a default cleanup action into what we want for a particular
         // node

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -19,47 +19,37 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-import com.microsoft.azure.vmagent.Messages;
 import com.microsoft.azure.util.AzureCredentials;
 import com.microsoft.azure.util.AzureCredentials.ServicePrincipal;
 import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.logging.Logger;
-
-import javax.servlet.ServletException;
-
-import jenkins.model.Jenkins;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-
 import com.microsoft.azure.vmagent.util.AzureUtil;
 import com.microsoft.azure.vmagent.util.Constants;
 import com.microsoft.azure.vmagent.util.FailureStage;
-
 import hudson.Extension;
 import hudson.RelativePath;
-import hudson.model.Describable;
-import hudson.model.TaskListener;
-import hudson.model.Descriptor;
-import hudson.model.Item;
-import hudson.model.Label;
-import hudson.model.Node;
+import hudson.model.*;
 import hudson.model.labels.LabelAtom;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.servlet.ServletException;
+import javax.xml.bind.DatatypeConverter;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
-import javax.xml.bind.DatatypeConverter;
-import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.AncestorInPath;
+import java.util.logging.Logger;
 
 /**
  * This class defines the configuration of Azure instance templates

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -19,54 +19,39 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.microsoft.azure.PagedList;
-import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.OperatingSystemTypes;
 import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.resources.Deployment;
 import com.microsoft.azure.management.resources.DeploymentOperation;
 import com.microsoft.azure.util.AzureCredentials;
+import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
 import com.microsoft.azure.vmagent.remote.AzureVMAgentSSHLauncher;
-import com.microsoft.azure.vmagent.util.AzureUtil;
-import com.microsoft.azure.vmagent.util.CleanUpAction;
+import com.microsoft.azure.vmagent.util.*;
+import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import hudson.model.*;
+import hudson.security.ACL;
+import hudson.slaves.Cloud;
+import hudson.slaves.NodeProvisioner.PlannedNode;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import hudson.util.StreamTaskListener;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
-
-import jenkins.model.Jenkins;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-
-import hudson.Extension;
-import hudson.model.Computer;
-import hudson.model.Descriptor;
-import hudson.model.Label;
-import hudson.model.Node;
-import hudson.slaves.Cloud;
-import hudson.slaves.NodeProvisioner.PlannedNode;
-import hudson.util.FormValidation;
-import hudson.util.StreamTaskListener;
-
-import com.microsoft.azure.vmagent.util.Constants;
-import com.microsoft.azure.vmagent.util.FailureStage;
-import com.microsoft.azure.vmagent.util.TokenCache;
-import hudson.init.InitMilestone;
-import hudson.init.Initializer;
-import hudson.model.Item;
-import hudson.security.ACL;
-import hudson.util.ListBoxModel;
-import java.nio.charset.Charset;
+import java.util.concurrent.*;
 import java.util.logging.Level;
-import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.AncestorInPath;
+import java.util.logging.Logger;
 
 public class AzureVMCloud extends Cloud {
 
@@ -117,7 +102,7 @@ public class AzureVMCloud extends Cloud {
             final String deploymentTimeout,
             final String resourceGroupName,
             final List<AzureVMAgentTemplate> vmTemplates) {
-        super(AzureUtil.getCloudName(credentials.getSubscriptionId()));
+        super(AzureUtil.getCloudName(credentials.getSubscriptionId(), resourceGroupName));
         this.credentials = credentials;
         this.credentialsId = azureCredentialsId;
         this.resourceGroupName = resourceGroupName;

--- a/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
@@ -50,7 +50,7 @@ public class AzureUtil {
     public static final String VAL_PASSWORD_REGEX = "([0-9a-zA-Z@#\\$%\\^&\\*-_!+=\\[\\]{}|\\\\:`,\\.\\?/~\"\\(\\);\']*{8,123})";
 
     public static final String VAL_ADMIN_USERNAME = "([a-zA-Z0-9_-]{3,15})";
-    
+
     public static final String VAL_TEMPLATE = "^[a-z][a-z0-9-]*[a-z0-9]$";
 
     /** Converts bytes to hex representation */
@@ -242,16 +242,17 @@ public class AzureUtil {
 
         return errorMessage.contains("The specified deployment slot Production is occupied");
     }
-    
+
     /**
      * Retrieves the name of the cloud for registering with Jenkins
      * @param subscriptionId Subscription id
+     * @param resourceGroupName Resource group name
      * @return Name of the cloud
      */
-    public static String getCloudName(String subscriptionId) {
-        return Constants.AZURE_CLOUD_PREFIX + subscriptionId;
+    public static String getCloudName(final String subscriptionId, final String resourceGroupName) {
+        return Constants.AZURE_CLOUD_PREFIX + subscriptionId + resourceGroupName;
     }
-    
+
     /**
      * Returns a template name that can be used for the base of a VM name
      * @return A shortened template name if required, the full name otherwise
@@ -265,7 +266,7 @@ public class AzureUtil {
         }
         // If the template name ends in a number, we add a dash
         // to split up the name
-        
+
         int maxLength;
         if (usageType.equals(Constants.OS_TYPE_LINUX)) {
             // Linux, length <= 63 characters, 10 characters for the date
@@ -282,25 +283,25 @@ public class AzureUtil {
         else {
             throw new IllegalArgumentException("Unknown OS/Usage type");
         }
-        
+
         // Chop of what we need for date digits
         maxLength -= dateDigits;
         // Chop off extra if needed for suffix digits
         maxLength -= extraSuffixDigits;
-        
+
         // Shorten the name
         String shortenedName = templateName.substring(0,Math.min(templateName.length(), maxLength));
-        
+
         // If the name ends in a digit, either append or replace the last char with a - so it's
         // not confusing
         if (StringUtils.isNumeric(shortenedName.substring(shortenedName.length()-1))) {
             shortenedName = shortenedName.substring(0, Math.min(templateName.length(), maxLength-1));
             shortenedName += '-';
         }
-        
+
         return shortenedName;
     }
-    
+
     /**
      * Returns true if the template name is valid, false otherwise
      * @param templateName Template name to validate
@@ -309,7 +310,7 @@ public class AzureUtil {
     public static boolean isValidTemplateName(String templateName) {
         return templateName.matches(VAL_TEMPLATE);
     }
-    
+
     /**
      * Creates a deployment given a template name and OS type
      * @param templateName Valid template name
@@ -320,38 +321,38 @@ public class AzureUtil {
         if (!isValidTemplateName(templateName)) {
             throw new IllegalArgumentException("Invalid template name");
         }
-        
+
         Format formatter = new SimpleDateFormat(Constants.DEPLOYMENT_NAME_DATE_FORMAT);
-        return String.format("%s%s", getShortenedTemplateName(templateName, Constants.USAGE_TYPE_DEPLOYMENT, 
-            Constants.DEPLOYMENT_NAME_DATE_FORMAT.length(), 0), 
+        return String.format("%s%s", getShortenedTemplateName(templateName, Constants.USAGE_TYPE_DEPLOYMENT,
+            Constants.DEPLOYMENT_NAME_DATE_FORMAT.length(), 0),
                 formatter.format(timestamp));
     }
-    
+
     /**
      * Creates a new VM base name given the input parameters.
      * @param templateName Template name
      * @param osType Type of OS
      * @param numberOfVmsToCreate Number of VMs that will be created
      *       (which is added to the suffix of the VM name by azure)
-     * @return 
+     * @return
      */
     public static String getVMBaseName(String templateName, String deploymentName, String osType, int numberOfVMs) {
         if (!isValidTemplateName(templateName)) {
             throw new IllegalArgumentException("Invalid template name");
         }
-        
+
         // For VM names, we use a simpler form.  VM names are pretty short 
         int numberOfDigits = (int)Math.floor(Math.log10((double)numberOfVMs))+1;
         // Get the hash of the deployment name
         Integer deploymentHashCode = deploymentName.hashCode();
         // Convert the int into a hex string and do a substring
-        String shortenedDeploymentHash = 
+        String shortenedDeploymentHash =
             Integer.toHexString(deploymentHashCode).substring(0, Constants.VM_NAME_HASH_LENGTH - 1);
-        return String.format("%s%s", getShortenedTemplateName(templateName, osType, 
-            Constants.VM_NAME_HASH_LENGTH, numberOfDigits), 
+        return String.format("%s%s", getShortenedTemplateName(templateName, osType,
+            Constants.VM_NAME_HASH_LENGTH, numberOfDigits),
                 shortenedDeploymentHash);
     }
-    
+
     public static StandardUsernamePasswordCredentials getCredentials(String credentialsId) throws AzureCloudException {
         // Grab the pass
         StandardUsernamePasswordCredentials creds = CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentials(
@@ -362,10 +363,10 @@ public class AzureUtil {
         if (creds == null) {
             throw new AzureCloudException("Could not find credentials with id: " + credentialsId);
         }
-        
+
         return creds;
     }
-    
+
     /**
      * Checks if the ResourceGroup Name is valid with Azure Standards
      * @param resourceGroupName Resource Group Name

--- a/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
@@ -250,7 +250,7 @@ public class AzureUtil {
      * @return Name of the cloud
      */
     public static String getCloudName(final String subscriptionId, final String resourceGroupName) {
-        return Constants.AZURE_CLOUD_PREFIX + subscriptionId + resourceGroupName;
+        return Constants.AZURE_CLOUD_PREFIX + subscriptionId + "-" + resourceGroupName;
     }
 
     /**


### PR DESCRIPTION
[FIXED JENKINS-43704]

- update the name for AzureVMCloud to use the combination of resourceGroupName and subscriptionId. Since resourceGroupName is unique in every subscripton, it should cover the scenario in the issue. If user try to add a new cloud profile with the same sub Id and the same resourceGroupName, the latter will be useless, Jenkins will always make use the first one. 
- Similarly for agetn template name, it could be the same among agent templates within different clouds. By using the combination of template name and cloud name, we can make sure to pick up the right template during verification process.  Again, if templates with same name exist in one single cloud, only the first templates got verified.