### PR TITLE
Various bugfixes

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -443,7 +443,7 @@ public class AzureVMAgent extends AbstractCloudSlave {
         // Adjust parent VM count up by one.
         AzureVMCloud parentCloud = getCloud();
         if (parentCloud != null) {
-            parentCloud.adjustVirtualMachineCount(1);
+            parentCloud.adjustVirtualMachineCount(-1);
         }
 
         Jenkins.getInstance().removeNode(this);

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -440,7 +440,7 @@ public class AzureVMAgent extends AbstractCloudSlave {
         AzureVMManagementServiceDelegate.terminateVirtualMachine(this);
         LOGGER.log(Level.INFO, "AzureVMAgent: deprovision: {0} has been deprovisioned. Remove node ...",
                 this.getDisplayName());
-        // Adjust parent VM count up by one.
+        // Adjust estimated virtual machine count.
         AzureVMCloud parentCloud = getCloud();
         if (parentCloud != null) {
             parentCloud.adjustVirtualMachineCount(-1);


### PR DESCRIPTION
* Avoid race where we can oversubscribe VMs because we do not adjust the estimated virtual machine count before attempting to allocate another set of VMs.  When there were large queues of various machine types, routinely attempted to allocate hundreds of VMs at once.
* Instead of listing all deployments, get deployment by name and then list operations.  This avoids an issue where the deployment list operation will fail on an unrelated deployment if it's being deleted.  Leads to failure to allocate new VMs
* Fix error message when deployment times out
* waitUntilOnline was blocking cleanup if a failure happened while waiting. Instead, ensure the cleanup is unblocked