### PR TITLE
Support cloud statistics plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <version>${azuresdk.version}</version>
       <type>jar</type>
     </dependency>
-    
+
      <dependency>
        <groupId>com.fasterxml.jackson.core</groupId>
        <artifactId>jackson-databind</artifactId>
@@ -102,13 +102,13 @@
        <artifactId>jackson-core</artifactId>
        <version>${jackson.version}</version>
      </dependency>
-    
+
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>azure-credentials</artifactId>
       <version>${azure-credentials.version}</version>
     </dependency>
-    
+
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
@@ -137,7 +137,7 @@
         </exclusions>
         <scope>provided</scope>
     </dependency>
-    
+
     <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-model</artifactId>
@@ -167,6 +167,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
       <version>1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloud-stats</artifactId>
+      <version>0.11</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMComputer.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMComputer.java
@@ -1,12 +1,12 @@
 /*
  Copyright 2016 Microsoft, Inc.
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,22 +22,29 @@ import com.microsoft.azure.vmagent.util.ExecutionEngine;
 import java.io.IOException;
 import java.util.logging.Logger;
 
+import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
+import org.jenkinsci.plugins.cloudstats.TrackedItem;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.OfflineCause;
+
+import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 
-public class AzureVMComputer extends AbstractCloudComputer<AzureVMAgent> {
+public class AzureVMComputer extends AbstractCloudComputer<AzureVMAgent> implements TrackedItem {
 
     private static final Logger LOGGER = Logger.getLogger(AzureVMComputer.class.getName());
+
+    private final ProvisioningActivity.Id provisioningId;
 
     private boolean setOfflineByUser = false;
 
     public AzureVMComputer(final AzureVMAgent agent) {
         super(agent);
+        this.provisioningId = agent.getId();
     }
 
     @Override
@@ -49,7 +56,7 @@ public class AzureVMComputer extends AbstractCloudComputer<AzureVMAgent> {
         checkPermission(DELETE);
         this.setAcceptingTasks(false);
         final AzureVMAgent agent = getNode();
-        
+
         if (agent != null) {
             Callable<Void> task = new Callable<Void>() {
                 @Override
@@ -69,13 +76,13 @@ public class AzureVMComputer extends AbstractCloudComputer<AzureVMAgent> {
             try {
                 executionEngine.executeAsync(task, new NoRetryStrategy());
             } catch (AzureCloudException exception) {
-                // No need to throw exception back, just log and move on. 
+                // No need to throw exception back, just log and move on.
                 LOGGER.log(Level.INFO,
                         "AzureVMComputer: execute: failed to shutdown/delete " + agent.getDisplayName(),
                         exception);
             }
         }
-        
+
         return new HttpRedirect("..");
     }
 
@@ -86,10 +93,10 @@ public class AzureVMComputer extends AbstractCloudComputer<AzureVMAgent> {
     public void setSetOfflineByUser(boolean setOfflineByUser) {
         this.setOfflineByUser = setOfflineByUser;
     }
-    
+
     /**
      * Wait until the node is online
-     * @throws InterruptedException 
+     * @throws InterruptedException
      */
     @Override
     public void waitUntilOnline() throws InterruptedException {
@@ -102,7 +109,7 @@ public class AzureVMComputer extends AbstractCloudComputer<AzureVMAgent> {
      * this plugin might set things temp-offline (vs. disconnect), we'll reset the bit
      * after calling setTemporarilyOffline
      * @param setOffline
-     * @param oc 
+     * @param oc
      */
     @Override
     public void setTemporarilyOffline(boolean setOffline, OfflineCause oc) {
@@ -116,11 +123,17 @@ public class AzureVMComputer extends AbstractCloudComputer<AzureVMAgent> {
      * this plugin might set things temp-offline (vs. disconnect), we'll reset the bit
      * after calling setTemporarilyOffline
      * @param setOffline
-     * @param oc 
+     * @param oc
      */
     @Override
     public void setTemporarilyOffline(boolean setOffline) {
         setSetOfflineByUser(setOffline);
         super.setTemporarilyOffline(setOffline);
+    }
+
+    @Nullable
+    @Override
+    public ProvisioningActivity.Id getId() {
+        return provisioningId;
     }
 }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -88,6 +88,8 @@ import jenkins.model.Jenkins;
 import jenkins.slaves.JnlpSlaveAgentProtocol;
 
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.cloudstats.CloudStatistics;
+import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
 
 /**
  * Business delegate class which handles calls to Azure management service SDK.
@@ -628,10 +630,12 @@ public class AzureVMManagementServiceDelegate {
      * @throws AzureCloudException
      */
     public static AzureVMAgent parseResponse(
+            final ProvisioningActivity.Id id,
             final String vmname,
             final String deploymentName,
             final AzureVMAgentTemplate template,
             final OperatingSystemTypes osType) throws AzureCloudException {
+
         try {
 
             LOGGER.log(Level.INFO, "AzureVMManagementServiceDelegate: parseDeploymentResponse: \n"
@@ -643,6 +647,7 @@ public class AzureVMManagementServiceDelegate {
             AzureVMCloud azureCloud = template.getAzureCloud();
 
             return new AzureVMAgent(
+                    id,
                     vmname,
                     template.getTemplateName(),
                     template.getTemplateDesc(),

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMCloud.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMCloud.java
@@ -25,6 +25,9 @@ import com.microsoft.azure.vmagent.util.Constants;
 import hudson.model.Node;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.jenkinsci.plugins.cloudstats.CloudStatistics;
+import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -39,6 +42,7 @@ public class ITAzureVMCloud extends IntegrationTest {
         try {
             final String vmName = "fakeVM";
             final String deploymentName = "fakeDeployment";
+            final ProvisioningActivity.Id provisioningId = new ProvisioningActivity.Id(vmName, deploymentName);
             AzureVMAgentTemplate templateMock = mock(AzureVMAgentTemplate.class);
             AzureVMCloud cloudMock = spy( new AzureVMCloud(servicePrincipal, "xyz", "42", "0", testEnv.azureResourceGroup, null));
 
@@ -46,7 +50,7 @@ public class ITAzureVMCloud extends IntegrationTest {
             when(cloudMock.getServicePrincipal()).thenReturn(servicePrincipal);
 
             try {
-                cloudMock.createProvisionedAgent(templateMock, vmName, deploymentName);
+                cloudMock.createProvisionedAgent(provisioningId, templateMock, vmName, deploymentName);
                 Assert.assertTrue(false);
             } catch (AzureCloudException ex) {
                 Assert.assertTrue(true);
@@ -79,6 +83,7 @@ public class ITAzureVMCloud extends IntegrationTest {
             final String agentLaunchMethod = Constants.LAUNCH_METHOD_SSH;
             final boolean executeInitScriptAsRoot = true;
             final boolean doNotUseMachineIfInitFails = true;
+            final ProvisioningActivity.Id provisioningId = new ProvisioningActivity.Id(vmName, deploymentName);
 
             AzureVMAgentTemplate templateMock = mock(AzureVMAgentTemplate.class);
             AzureVMCloud cloudMock = spy( new AzureVMCloud(servicePrincipal, credentialsId, "42", "30", testEnv.azureResourceGroup, null));
@@ -101,7 +106,7 @@ public class ITAzureVMCloud extends IntegrationTest {
             when(templateMock.getExecuteInitScriptAsRoot()).thenReturn(executeInitScriptAsRoot);
             when(templateMock.getDoNotUseMachineIfInitFails()).thenReturn(doNotUseMachineIfInitFails);
 
-            AzureVMAgent newAgent = cloudMock.createProvisionedAgent(templateMock, vmName, deploymentName);
+            AzureVMAgent newAgent = cloudMock.createProvisionedAgent(provisioningId, templateMock, vmName, deploymentName);
 
             Assert.assertEquals(vmDNS, newAgent.getPublicDNSName());
             Assert.assertEquals(Constants.DEFAULT_SSH_PORT, newAgent.getSshPort());


### PR DESCRIPTION
This PR added support for [Cloud Statistics Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Cloud+Statistics+Plugin) as requested by [JENKINS-42799](https://issues.jenkins-ci.org/browse/JENKINS-42799).

Cloud Statistics Plugin aggregates cloud provisioning activities and has about 800 downloads last month. By integrating with this plugin I think it may be useful for user to track their Azure cloud agents.

Here is a screenshot:

![image](https://cloud.githubusercontent.com/assets/858914/26484321/02e8acbe-4224-11e7-8d20-b5156ba7bdb4.png)
