### PR TITLE
Catch all possible exceptions from Azure SDK and strip HTTP details

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/util/TokenCache.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/TokenCache.java
@@ -23,6 +23,7 @@ import com.microsoft.azure.util.AzureCredentials;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
@@ -91,12 +92,16 @@ public class TokenCache {
         );
     }
 
-    public Azure getAzureClient() {
-        return Azure
-                .configure()
-                .withLogLevel(Constants.DEFAULT_AZURE_SDK_LOGGING_LEVEL)
-                .withUserAgent(getUserAgent())
-                .authenticate(get(credentials))
-                .withSubscription(credentials.getSubscriptionId());
+    public Azure getAzureClient() throws AzureCloudException {
+        try {
+            return Azure
+                    .configure()
+                    .withLogLevel(Constants.DEFAULT_AZURE_SDK_LOGGING_LEVEL)
+                    .withUserAgent(getUserAgent())
+                    .authenticate(get(credentials))
+                    .withSubscription(credentials.getSubscriptionId());
+        } catch (Exception e) {
+            throw AzureCloudException.create(e);
+        }
     }
 }

--- a/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
@@ -174,11 +174,14 @@ public class IntegrationTest {
             if (e.response().code() != 404) {
                 LOGGER.log(Level.SEVERE, null, e);
             }
+        } catch (AzureCloudException e) {
+            LOGGER.log(Level.SEVERE, null, e);
         }
-        
+
     }
 
-    protected String downloadFromAzure(final String resourceGroup, final String storageAccountName, final String containerName, final String fileName) throws URISyntaxException, StorageException, IOException {
+    protected String downloadFromAzure(final String resourceGroup, final String storageAccountName, final String containerName, final String fileName)
+            throws URISyntaxException, StorageException, IOException, AzureCloudException {
         List<StorageAccountKey> storageKeys = customTokenCache.getAzureClient().storageAccounts().getByGroup(resourceGroup, storageAccountName).getKeys();
         String storageAccountKey = storageKeys.get(0).value();
         CloudStorageAccount account = new CloudStorageAccount(new StorageCredentialsAccountAndKey(storageAccountName, storageAccountKey));
@@ -324,7 +327,7 @@ public class IntegrationTest {
         throw new Exception("Deployment is not completed after 10 minutes");
     }
     
-    protected boolean areAllVMsDeployed(final List<String> vmNames) {
+    protected boolean areAllVMsDeployed(final List<String> vmNames) throws AzureCloudException {
         int deployedVMs = 0;
         PagedList<Deployment> deployments= customTokenCache.getAzureClient().deployments().listByGroup(testEnv.azureResourceGroup);
         for (Deployment dep : deployments) {
@@ -357,10 +360,12 @@ public class IntegrationTest {
         return deployedVMs == vmNames.size();
     }
 
-    protected VirtualMachine createAzureVM(final String vmName) throws CloudException, IOException {
+    protected VirtualMachine createAzureVM(final String vmName)
+            throws CloudException, IOException, AzureCloudException {
         return createAzureVM(vmName, "JenkinsTag", "testing");
     }
-    protected VirtualMachine createAzureVM(final String vmName, final String tagName, final String tagValue) throws CloudException, IOException {
+    protected VirtualMachine createAzureVM(final String vmName, final String tagName, final String tagValue)
+            throws CloudException, IOException, AzureCloudException {
         return customTokenCache.getAzureClient().virtualMachines()
                 .define(vmName)
                 .withRegion(testEnv.azureLocation)


### PR DESCRIPTION
@LGDoor just found another crash of Cloud Statistics Plugin. According to my investigation, it's still caused by failing to deserialize class `CloudException` in Azure SDK. In fact it seems that all RPC related methods in Azure SDK may throw exceptions, though not specified in interfaces. So we have to catch exceptions at all those places and strip unnecessary details to avoid them recorded by Cloud Statistics Plugin directly.