### PR TITLE
make *.sh files to always checkout as lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 *.json text eol=lf
 *.ps1 text
 *.html text eol=lf
+*.sh text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary


### PR DESCRIPTION
To fix the issue that shell script with crlf cannot run correctly in Linux.