### PR TITLE
Fix a bug for throwing exception of missing doFillXyzItems function

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -969,6 +969,10 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate> {
             return model;
         }
 
+        public String doFillImageReferenceTypeItems() {
+            return null;
+        }
+
         public FormValidation doAgentLaunchMethod(@QueryParameter String value) {
             if (Constants.LAUNCH_METHOD_JNLP.equals(value)) {
                 return FormValidation.warning(Messages.Azure_GC_LaunchMethod_Warn_Msg());


### PR DESCRIPTION
I add a ```doFillImageReferenceTypeItems``` function returns null, it can eliminate the exception:
```class com.microsoft.azure.vmagent.AzureVMAgentTemplate$DescriptorImpl doesn't have the doFillImageReferenceTypeItems method for filling a drop-down list``` as described in #69 @rtyler 

The ```doFillImageReferenceTypeItems``` function is used for dynamic databinding, i.e. show defferent options depend on another tag, return null means display the default option. 

If you don't need this feature, missing ```doFillImageReferenceTypeItems``` is okay, since it is only used for databinding now, the warning has no harm to functionality, but with a ```doFillImageReferenceTypeItems``` with returning null can make the excption disappear in the console.