### PR TITLE
Use a more accurate method to determine whether the node was set offl…

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -331,8 +331,6 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
         if (computer != null) {
             // Set the machine temporarily offline machine with an offline reason.
             computer.setTemporarilyOffline(true, OfflineCause.create(reason));
-            // Reset the "by user" bit.
-            computer.setSetOfflineByUser(false);
         }
         setCleanUpAction(action);
         setCleanUpReason(reason);

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMComputer.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMComputer.java
@@ -37,8 +37,6 @@ public class AzureVMComputer extends AbstractCloudComputer<AzureVMAgent> impleme
 
     private final ProvisioningActivity.Id provisioningId;
 
-    private boolean setOfflineByUser = false;
-
     public AzureVMComputer(AzureVMAgent agent) {
         super(agent);
         this.provisioningId = agent.getId();
@@ -88,11 +86,7 @@ public class AzureVMComputer extends AbstractCloudComputer<AzureVMAgent> impleme
     }
 
     public boolean isSetOfflineByUser() {
-        return setOfflineByUser;
-    }
-
-    public void setSetOfflineByUser(boolean setOfflineByUser) {
-        this.setOfflineByUser = setOfflineByUser;
+        return (this.getOfflineCause() instanceof OfflineCause.UserCause);
     }
 
     /**
@@ -103,35 +97,6 @@ public class AzureVMComputer extends AbstractCloudComputer<AzureVMAgent> impleme
     @Override
     public void waitUntilOnline() throws InterruptedException {
         super.waitUntilOnline();
-    }
-
-    /**
-     * We use temporary offline settings to do investigation of machines.
-     * To avoid deletion, we assume this came through a user call and set a bit.  Where
-     * this plugin might set things temp-offline (vs. disconnect), we'll reset the bit
-     * after calling setTemporarilyOffline
-     *
-     * @param setOffline
-     * @param oc
-     */
-    @Override
-    public void setTemporarilyOffline(boolean setOffline, OfflineCause oc) {
-        setSetOfflineByUser(setOffline);
-        super.setTemporarilyOffline(setOffline, oc);
-    }
-
-    /**
-     * We use temporary offline settings to do investigation of machines.
-     * To avoid deletion, we assume this came through a user call and set a bit.  Where
-     * this plugin might set things temp-offline (vs. disconnect), we'll reset the bit
-     * after calling setTemporarilyOffline
-     *
-     * @param setOffline
-     */
-    @Override
-    public void setTemporarilyOffline(boolean setOffline) {
-        setSetOfflineByUser(setOffline);
-        super.setTemporarilyOffline(setOffline);
     }
 
     @Nullable


### PR DESCRIPTION
…ine by the user

We were overriding setTemporarilyOffline before, with the knowledge that cases where a node was set offline by Jenkins internal mechanisms were not going through this method.  In newer versions of Jenkins this appears not to be the case.  So in some corner cases (restart, node is set offline by thread pool termination, etc.) we were blocking node cleanup.  Instead, check the type of the offline cause, which will be UserCause if the node was set offline by the user.