### PR TITLE
Improvements on slaves to save money

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -326,7 +326,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         Map<String, String> defaultProperties =
                 AzureVMManagementServiceDelegate.DEFAULT_IMAGE_PROPERTIES.get(builtInImage);
         boolean isBasic = template.isTopLevelType(Constants.IMAGE_TOP_LEVEL_BASIC);
-		String imageSkuName = template.getIsInstallDocker() ? Constants.DEFAULT_DOCKER_IMAGE_SKU : Constants.DEFAULT_IMAGE_SKU;
+        String imageSkuName =
+                template.getIsInstallDocker() ? Constants.DEFAULT_DOCKER_IMAGE_SKU : Constants.DEFAULT_IMAGE_SKU;
 
         templateProperties.put("imagePublisher",
                 isBasic ? defaultProperties.get(Constants.DEFAULT_IMAGE_PUBLISHER) : template.getImagePublisher());

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -326,13 +326,14 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         Map<String, String> defaultProperties =
                 AzureVMManagementServiceDelegate.DEFAULT_IMAGE_PROPERTIES.get(builtInImage);
         boolean isBasic = template.isTopLevelType(Constants.IMAGE_TOP_LEVEL_BASIC);
+		String imageSkuName = template.getIsInstallDocker() ? Constants.DEFAULT_DOCKER_IMAGE_SKU : Constants.DEFAULT_IMAGE_SKU;
 
         templateProperties.put("imagePublisher",
                 isBasic ? defaultProperties.get(Constants.DEFAULT_IMAGE_PUBLISHER) : template.getImagePublisher());
         templateProperties.put("imageOffer",
                 isBasic ? defaultProperties.get(Constants.DEFAULT_IMAGE_OFFER) : template.getImageOffer());
         templateProperties.put("imageSku",
-                isBasic ? defaultProperties.get(Constants.DEFAULT_IMAGE_SKU) : template.getImageSku());
+                isBasic ? defaultProperties.get(imageSkuName) : template.getImageSku());
         templateProperties.put("imageVersion",
                 isBasic ? defaultProperties.get(Constants.DEFAULT_IMAGE_VERSION) : template.getImageVersion());
         templateProperties.put("osType",
@@ -389,7 +390,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
                         AzureVMManagementServiceDelegate.PRE_INSTALLED_TOOLS_SCRIPT
                                 .get(template.getBuiltInImage()).get(Constants.INSTALL_DOCKER)
                                 .replace("${ADMIN}",
-                                        AzureUtil.getCredentials(template.getCredentialsId()).getUsername()));
+                                        template.getVMCredentials().getUsername()));
             }
             return stringBuilder.toString();
         } catch (Exception e) {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -699,11 +699,9 @@ public class AzureVMCloud extends Cloud {
                         if (AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
                             numberOfAgents--;
 
-                            plannedNodes.add(new TrackedPlannedNode(
-                                    provisioningId,
+                            plannedNodes.add(new TrackedPlannedNode(provisioningId,
                                     template.getNoOfParallelJobs(),
                                     Computer.threadPoolForRemoting.submit(new Callable<Node>() {
-
                                         @Override
                                         public Node call() throws AzureCloudException {
                                             LOGGER.log(Level.INFO, "Found existing node, starting VM {0}",

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -137,6 +137,7 @@ public final class AzureVMManagementServiceDelegate {
 
     private static final String INSTALL_DOCKER_UBUNTU_FILENAME = "/scripts/ubuntuInstallDockerScript.sh";
 
+
     private static final String PRE_INSTALL_SSH_FILENAME = "/scripts/sshInit.ps1";
 
     private final Azure azureClient;
@@ -1103,6 +1104,7 @@ public final class AzureVMManagementServiceDelegate {
                 Constants.DEFAULT_IMAGE_PUBLISHER, "MicrosoftWindowsServer");
         imageProperties.get(Constants.WINDOWS_SERVER_2016).put(Constants.DEFAULT_IMAGE_OFFER, "WindowsServer");
         imageProperties.get(Constants.WINDOWS_SERVER_2016).put(Constants.DEFAULT_IMAGE_SKU, "2016-Datacenter");
+        imageProperties.get(Constants.WINDOWS_SERVER_2016).put(Constants.DEFAULT_DOCKER_IMAGE_SKU, "2016-Datacenter-with-Containers");
         imageProperties.get(Constants.WINDOWS_SERVER_2016).put(Constants.DEFAULT_IMAGE_VERSION, "latest");
         imageProperties.get(Constants.WINDOWS_SERVER_2016).put(Constants.DEFAULT_OS_TYPE, Constants.OS_TYPE_WINDOWS);
         imageProperties.get(Constants.WINDOWS_SERVER_2016).put(
@@ -1111,6 +1113,7 @@ public final class AzureVMManagementServiceDelegate {
         imageProperties.get(Constants.UBUNTU_1604_LTS).put(Constants.DEFAULT_IMAGE_PUBLISHER, "Canonical");
         imageProperties.get(Constants.UBUNTU_1604_LTS).put(Constants.DEFAULT_IMAGE_OFFER, "UbuntuServer");
         imageProperties.get(Constants.UBUNTU_1604_LTS).put(Constants.DEFAULT_IMAGE_SKU, "16.04-LTS");
+        imageProperties.get(Constants.UBUNTU_1604_LTS).put(Constants.DEFAULT_DOCKER_IMAGE_SKU, "16.04-LTS");
         imageProperties.get(Constants.UBUNTU_1604_LTS).put(Constants.DEFAULT_IMAGE_VERSION, "latest");
         imageProperties.get(Constants.UBUNTU_1604_LTS).put(Constants.DEFAULT_OS_TYPE, Constants.OS_TYPE_LINUX);
         imageProperties.get(Constants.UBUNTU_1604_LTS).put(

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -1417,7 +1417,7 @@ public final class AzureVMManagementServiceDelegate {
 
         try {
             azureClient.virtualMachines()
-                    .getByResourceGroup(agent.getResourceGroupName(), agent.getNodeName()).powerOff();
+                    .getByResourceGroup(agent.getResourceGroupName(), agent.getNodeName()).deallocate();
         } catch (Exception e) {
             LOGGER.log(Level.INFO,
                     "AzureVMManagementServiceDelegate: provision: could not terminate or shutdown {0}, {1}",

--- a/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
@@ -123,6 +123,7 @@ public final class Constants {
     public static final String DEFAULT_IMAGE_PUBLISHER = "defaultImagePublisher";
     public static final String DEFAULT_IMAGE_OFFER = "defaultImageOffer";
     public static final String DEFAULT_IMAGE_SKU = "defaultImageSku";
+    public static final String DEFAULT_DOCKER_IMAGE_SKU = "defaultDockerImageSku";
     public static final String DEFAULT_IMAGE_VERSION = "defaultImageVersion";
     public static final String DEFAULT_OS_TYPE = "defaultOsType";
     public static final String DEFAULT_LAUNCH_METHOD = "defaultLaunchMethod";

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
@@ -82,7 +82,7 @@
                         <f:checkbox/>
                     </f:entry>
 
-                    <f:entry title="Install Docker (Only for Linux)" field="isInstallDocker">
+                    <f:entry title="Install Docker" field="isInstallDocker">
                         <f:checkbox/>
                     </f:entry>
                 </f:section>


### PR DESCRIPTION
- Use deallocate rather than stop to save money on azure
- Allow windows docker support via the checkbox (using "2016-Datacenter-with-Containers" sku)