### PR TITLE
make sure we have all git (linux) tools at our fingertips, to omit er…

### DIFF
--- a/src/main/resources/scripts/windowsInstallGitScript.ps1
+++ b/src/main/resources/scripts/windowsInstallGitScript.ps1
@@ -10,6 +10,6 @@ $webClient = New-Object System.Net.WebClient
 $webClient.DownloadFile($source, $destination)
 $proc = Start-Process -FilePath $destination -ArgumentList "/VERYSILENT" -Wait -PassThru
 $proc.WaitForExit()
-$Env:Path += ";C:\Program Files\Git\cmd"
+$Env:Path += ";C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin"
 #Disable git credential manager, get more details in https://support.cloudbees.com/hc/en-us/articles/221046888-Build-Hang-or-Fail-with-Git-for-Windows
 git config --system --unset credential.helper


### PR DESCRIPTION
Fix error: Cannot run program "nohup", if we're working with docker on windows