### PR TITLE
Remove sleep while shutting down an Azure VM.

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudOnceRetentionStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudOnceRetentionStrategy.java
@@ -18,7 +18,6 @@ public class AzureVMCloudOnceRetentionStrategy extends AzureVMCloudBaseRetention
     private static final Logger LOGGER = Logger.getLogger(AzureVMManagementServiceDelegate.class.getName());
     private static final long serialVersionUID = 1566788691L;
     private static final transient long IDLE_MILLIS = TimeUnit2.MINUTES.toMillis(1);
-    private static final transient long WAIT_TIME = TimeUnit2.SECONDS.toMillis(10);
     private static final transient long LAPSE = TimeUnit2.SECONDS.toMillis(5);
 
     @DataBoundConstructor
@@ -71,12 +70,6 @@ public class AzureVMCloudOnceRetentionStrategy extends AzureVMCloudBaseRetention
     }
 
     public void done(AzureVMComputer computer) {
-        try {
-            Thread.sleep(WAIT_TIME);
-        } catch (Exception e) {
-            LOGGER.info(e.getMessage());
-        }
-
         final AzureVMAgent agent = computer.getNode();
         if (agent == null) {
             return;


### PR DESCRIPTION
We observe this stack trace, with the Jenkins UI largely unresponsive:

```"pool-48-thread-406" #55287 prio=5 os_prio=0 tid=0x00007f10e499e800 nid=0x3307 waiting on condition [0x00007f10c1463000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at com.microsoft.azure.vmagent.AzureVMCloudOnceRetentionStrategy.done(AzureVMCloudOnceRetentionStrategy.java:75)
	at com.microsoft.azure.vmagent.AzureVMCloudOnceRetentionStrategy.check(AzureVMCloudOnceRetentionStrategy.java:36)
	at com.microsoft.azure.vmagent.AzureVMCloudOnceRetentionStrategy.check(AzureVMCloudOnceRetentionStrategy.java:17)
	at hudson.slaves.SlaveComputer$4.run(SlaveComputer.java:768)
	at hudson.model.Queue._withLock(Queue.java:1375)
	at hudson.model.Queue.withLock(Queue.java:1252)
	at hudson.slaves.SlaveComputer.setNode(SlaveComputer.java:765)
	at hudson.model.AbstractCIBase.updateComputer(AbstractCIBase.java:121)
	at hudson.model.AbstractCIBase.access$000(AbstractCIBase.java:46)
	at hudson.model.AbstractCIBase$2.run(AbstractCIBase.java:207)
	at hudson.model.Queue._withLock(Queue.java:1375)
	at hudson.model.Queue.withLock(Queue.java:1252)
	at hudson.model.AbstractCIBase.updateComputerList(AbstractCIBase.java:190)
	at jenkins.model.Jenkins.updateComputerList(Jenkins.java:1545)
	at jenkins.model.Nodes$5.run(Nodes.java:246)
	at hudson.model.Queue._withLock(Queue.java:1375)
	at hudson.model.Queue.withLock(Queue.java:1252)
	at jenkins.model.Nodes.removeNode(Nodes.java:237)
	at jenkins.model.Jenkins.removeNode(Jenkins.java:2059)
	at com.microsoft.azure.vmagent.AzureVMAgent.deprovision(AzureVMAgent.java:501)
	- locked <0x00000006d69094a8> (a com.microsoft.azure.vmagent.AzureVMAgent)
	at com.microsoft.azure.vmagent.AzureVMAgentCleanUpTask$2.call(AzureVMAgentCleanUpTask.java:538)
	at com.microsoft.azure.vmagent.AzureVMAgentCleanUpTask$2.call(AzureVMAgentCleanUpTask.java:530)
	at com.microsoft.azure.vmagent.retry.RetryTask.call(RetryTask.java:49)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

The Azure plugin is sleeping for 10 seconds with the queue lock held, and lots of other operations that need the queue lock (agents starting and stopping, jobs scheduling, other VMs being decommissioned) are blocked until this is complete.

As far as I can see, there is no reason for this wait to be there -- am I missing something?