### PR TITLE
Fix missing plan info for reference image configution

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -293,21 +293,23 @@ public final class AzureVMManagementServiceDelegate {
             putVariable(tmp, "resourceTag", deploymentRegistrar.getDeploymentTag().get());
             putVariable(tmp, "cloudTag", template.getAzureCloud().getCloudName());
 
-            // add purchase plan for image if needed
-            VirtualMachineImage image = azureClient.virtualMachineImages().getImage(locationName,
-                    template.getImagePublisher(), template.getImageOffer(), template.getImageSku(), template.getImageVersion());
-            if (image != null) {
-                PurchasePlan plan = image.plan();
-                if (plan != null) {
-                    ArrayNode resources = (ArrayNode) tmp.get("resources");
-                    for (JsonNode resource : resources) {
-                        String type = resource.get("type").asText();
-                        if(type.contains("virtualMachine")){
-                            ObjectNode planNode = mapper.createObjectNode();
-                            planNode.put("name", plan.name());
-                            planNode.put("publisher", plan.publisher());
-                            planNode.put("product", plan.product());
-                            ObjectNode.class.cast(resource).replace("plan", planNode);
+            // add purchase plan for image if needed in reference configuration
+            if (!useCustomImage && StringUtils.isBlank(template.getImageId())) {
+                VirtualMachineImage image = azureClient.virtualMachineImages().getImage(locationName,
+                        template.getImagePublisher(), template.getImageOffer(), template.getImageSku(), template.getImageVersion());
+                if (image != null) {
+                    PurchasePlan plan = image.plan();
+                    if (plan != null) {
+                        ArrayNode resources = (ArrayNode) tmp.get("resources");
+                        for (JsonNode resource : resources) {
+                            String type = resource.get("type").asText();
+                            if (type.contains("virtualMachine")) {
+                                ObjectNode planNode = mapper.createObjectNode();
+                                planNode.put("name", plan.name());
+                                planNode.put("publisher", plan.publisher());
+                                planNode.put("product", plan.product());
+                                ObjectNode.class.cast(resource).replace("plan", planNode);
+                            }
                         }
                     }
                 }

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
@@ -199,6 +199,55 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
     }
 
     @Test
+    public void createDeploymentWithPurchasePlan() throws Exception {
+        testEnv.azureImagePublisher = "kali-linux";
+        testEnv.azureImageOffer = "kali-linux";
+        testEnv.azureImageSku = "kali";
+
+        AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrar = mock(AzureVMAgentCleanUpTask.DeploymentRegistrar.class);
+        when(deploymentRegistrar.getDeploymentTag()).thenReturn(new AzureUtil.DeploymentTag("some_tag/123"));
+        AzureVMDeploymentInfo deploymentInfo;
+        deploymentInfo = createDefaultDeployment(1, deploymentRegistrar);
+
+        verify(deploymentRegistrar).registerDeployment(null, testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null);
+        Network actualVNet = null;
+        StorageAccount actualStorageAcc = null;
+        try {
+            actualVNet = azureClient.networks().getByResourceGroup(testEnv.azureResourceGroup, "jenkinsarm-vnet");
+            actualStorageAcc = azureClient.storageAccounts().getByResourceGroup(testEnv.azureResourceGroup, testEnv.azureStorageAccountName);
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, null, e);
+        }
+        Assert.assertNotNull("The deployed VNet doesn't exist: " + testEnv.azureResourceGroup, actualVNet);
+        Assert.assertNotNull("The deployed Storage Account doesn't exist: " + testEnv.azureResourceGroup, actualStorageAcc);
+
+        final String baseName = deploymentInfo.getVmBaseName() + "0";
+        final String commonAssertMsg = testEnv.azureResourceGroup + ":" + baseName;
+        VirtualMachine actualVM = null;
+        NetworkInterface actualNetIface = null;
+        PublicIPAddress actualIP = null;
+        try {
+            actualVM = azureClient
+                    .virtualMachines()
+                    .getByResourceGroup(testEnv.azureResourceGroup, baseName);
+
+            actualNetIface = azureClient
+                    .networkInterfaces()
+                    .getByResourceGroup(testEnv.azureResourceGroup, baseName + "NIC");
+
+            actualIP = azureClient
+                    .publicIPAddresses()
+                    .getByResourceGroup(testEnv.azureResourceGroup, baseName + "IPName");
+
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, null, e);
+        }
+        Assert.assertNotNull("The deployed VM doesn't exist: " + commonAssertMsg, actualVM);
+        Assert.assertNotNull("The deployed Network interface doesn't exist: " + commonAssertMsg, actualNetIface);
+        Assert.assertNotNull("The deployed public IP doesn't exist: " + commonAssertMsg, actualIP);
+    }
+
+    @Test
     public void canDeployMultipleTimes() {
         try {
             AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrar = mock(AzureVMAgentCleanUpTask.DeploymentRegistrar.class);

--- a/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
@@ -91,9 +91,9 @@ public class IntegrationTest {
         public final String azureStorageAccountName;
         public final String azureStorageAccountType;
         public final String azureImageId;
-        public final String azureImagePublisher;
-        public final String azureImageOffer;
-        public final String azureImageSku;
+        public String azureImagePublisher;
+        public String azureImageOffer;
+        public String azureImageSku;
         public final String azureImageSize;
         public final Map<String, String> blobEndpointSuffixForTemplate;
         public final Map<String, String> blobEndpointSuffixForCloudStorageAccount;


### PR DESCRIPTION
[jira issue JENKINS-52407](https://issues.jenkins-ci.org/browse/JENKINS-52407?jql=status%20%3D%20Open%20AND%20component%20in%20(azure-acs-plugin%2C%20azure-ad-plugin%2C%20azure-app-service-plugin%2C%20azure-commons-plugin%2C%20azure-container-agents-plugin%2C%20azure-credentials-plugin%2C%20azure-function-plugin%2C%20azure-slave-plugin%2C%20azure-vm-agents-plugin%2C%20azure-vmss-plugin%2C%20kubernetes-cd-plugin%2C%20windows-azure-storage-plugin))

Some VM images in the Azure Marketplace have additional license and purchase terms that you must accept before you can deploy them programmatically. You only need to do this one time in your subscription. After you have accepted the license, this plugin will auto get the purchase plan and make the request with it when you create VM by this plugin.