### PR TITLE
Check image parameters before add plan info

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -294,6 +294,8 @@ public final class AzureVMManagementServiceDelegate {
             putVariable(tmp, "cloudTag", template.getAzureCloud().getCloudName());
 
             // add purchase plan for image if needed in reference configuration
+            // Image Configuration has four choices, isBasic->Built-in Image, useCustomImage->Custom User Image
+            // getImageId()->Custom Managed Image, here we need the last one: Image Reference
             if (!isBasic && !useCustomImage && StringUtils.isBlank(template.getImageId())) {
                 boolean isImageParameterValid = checkImageParameter(template);
                 if (isImageParameterValid) {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -314,6 +314,11 @@ public final class AzureVMManagementServiceDelegate {
                                 }
                             }
                         }
+                    } else {
+                        LOGGER.log(Level.SEVERE, "Failed to find the image with publisher:{0} offer:{1} sku:{2} " +
+                                "version:{3} when trying to add purchase plan to ARM template", new Object[]{
+                                template.getImagePublisher(), template.getImageOffer(), template.getImageSku(),
+                                template.getImageVersion()});
                     }
                 }
             }
@@ -432,7 +437,7 @@ public final class AzureVMManagementServiceDelegate {
                 || StringUtils.isBlank(template.getImageOffer())
                 || StringUtils.isBlank(template.getImageSku())
                 || StringUtils.isBlank(template.getImageVersion())) {
-            LOGGER.warning("Missing Image Reference information when trying to add purchase plan to ARM template");
+            LOGGER.log(Level.SEVERE, "Missing Image Reference information when trying to add purchase plan to ARM template");
             return false;
         }
         return true;


### PR DESCRIPTION
There are four image types:
- Basic
- Custom User Image
- Custom Managed Image
- Image Reference

Only in Image Reference type we will try to add plan info when it is necessary. In this scenario, if the parameters are invalid, we will skip adding plan info and let the origin program to deal with the situation.