### PR TITLE
Manage azure-client-runtime dependency by plugin itself

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,17 @@
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure</artifactId>
             <version>${azuresdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.microsoft.azure</groupId>
+                    <artifactId>azure-client-runtime</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-client-runtime</artifactId>
+            <version>1.5.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Associated with [JENKINS-52838](https://issues.jenkins-ci.org/browse/JENKINS-52838)

Analyse: Azure package depend azure-client-runtime package by version range. Azure-client-runtime's auto upgrading causes its dependencies jackson upgrading which causes this issue.  

Solution: manage azure-client-runtime version by our plugin for now, we should upgrade azure package version later.