### PR TITLE
Add com.nimbusds in maskClasses to avoid linkageError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
                         com.microsoft.jenkins.azurecommons.core.
                         com.fasterxml.jackson.
                         com.google.common.
+                        com.nimbusds.
 
                         com.microsoft.azure.AzureAsyncOperation
                         com.microsoft.azure.AzureClient


### PR DESCRIPTION
Install both ad plugin and vm plugin will cause LinkageError for OIDCTokens class. Mask all the nimbusds classes.