### PR TITLE
Use https to communicate with storage account

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -2512,7 +2512,7 @@ public final class AzureVMManagementServiceDelegate {
         try {
             return new CloudStorageAccount(
                     new StorageCredentialsAccountAndKey(storageAccount.name(), storageAccountKey),
-                    false,
+                    true,
                     blobSuffix);
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE,


### PR DESCRIPTION
Jira issue [JENKINS-52967](https://issues.jenkins-ci.org/browse/JENKINS-52967).

This plugin should default use https when communicate with storage account. This method is used to upload custom scripts.