### PR TITLE
Image Reference Version

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -344,6 +344,7 @@ public final class AzureVMManagementServiceDelegate {
             copyVariableIfNotBlank(tmp, properties, "imagePublisher");
             copyVariableIfNotBlank(tmp, properties, "imageOffer");
             copyVariableIfNotBlank(tmp, properties, "imageSku");
+            copyVariableIfNotBlank(tmp, properties, "imageVersion");
             copyVariableIfNotBlank(tmp, properties, "osType");
             putVariableIfNotBlank(tmp, "image", template.getImage());
 

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -83,7 +83,7 @@
                         "publisher": "[variables('imagePublisher')]",
                         "offer": "[variables('imageOffer')]",
                         "sku": "[variables('imageSku')]",
-                        "version": "latest"
+                        "version": "[variables('imageVersion')]"
                     },
                     "osDisk": {
                         "name": "osdisk",

--- a/src/main/resources/referenceImageTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithManagedDisk.json
@@ -83,7 +83,7 @@
             "publisher": "[variables('imagePublisher')]",
             "offer": "[variables('imageOffer')]",
             "sku": "[variables('imageSku')]",
-            "version": "latest"
+            "version": "[variables('imageVersion')]"
           },
           "osDisk": {
             "createOption": "FromImage"

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -91,7 +91,7 @@
                         "publisher": "[variables('imagePublisher')]",
                         "offer": "[variables('imageOffer')]",
                         "sku": "[variables('imageSku')]",
-                        "version": "latest"
+                        "version": "[variables('imageVersion')]"
                     },
                     "osDisk": {
                         "name": "osdisk",

--- a/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
@@ -91,7 +91,7 @@
             "publisher": "[variables('imagePublisher')]",
             "offer": "[variables('imageOffer')]",
             "sku": "[variables('imageSku')]",
-            "version": "latest"
+            "version": "[variables('imageVersion')]"
           },
           "osDisk": {
             "createOption": "FromImage"


### PR DESCRIPTION
Use image version in the ImageReference templates instead of hardcoding latest.

From the Jenkins Configuration, I was expecting the image version field to translate to the ARM template.
The version is available already, so this change is just piping the field to the template

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/azure-vm-agents-plugin/126)
<!-- Reviewable:end -->
