### PR TITLE
Fix verify storagename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,11 +259,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>3.0.0-M1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <forkCount>3</forkCount>
                     <reuseForks>true</reuseForks>

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -2211,7 +2211,7 @@ public final class AzureVMManagementServiceDelegate {
             CheckNameAvailabilityResult checkResult =
                     azureClient.storageAccounts().checkNameAvailability(storageAccountName);
             isAvailable = checkResult.isAvailable();
-            if (!isAvailable && checkResult.reason().equals(Reason.ACCOUNT_NAME_INVALID)) {
+            if (!isAvailable && Reason.ACCOUNT_NAME_INVALID.equals(checkResult.reason())) {
                 return Messages.Azure_GC_Template_SA_Not_Valid();
             } else if (!isAvailable) {
                 /*if it's not available we need to check if it's already in our resource group*/
@@ -2232,7 +2232,7 @@ public final class AzureVMManagementServiceDelegate {
                 return Constants.OP_SUCCESS;
             }
         } catch (Exception e) {
-            LOGGER.log(Level.INFO, e.getMessage());
+            LOGGER.log(Level.SEVERE, "Fail to verify storage account name", e);
             if (!isAvailable) {
                 return Messages.Azure_GC_Template_SA_Already_Exists();
             } else {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -2232,7 +2232,7 @@ public final class AzureVMManagementServiceDelegate {
                 return Constants.OP_SUCCESS;
             }
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Fail to verify storage account name", e);
+            LOGGER.log(Level.SEVERE, "Verification failed for storage account name", e);
             if (!isAvailable) {
                 return Messages.Azure_GC_Template_SA_Already_Exists();
             } else {


### PR DESCRIPTION
Things are weird here, when the storage account name is invalid the reason will return normally. So switch the equal objects can avoid the NullPointer exception caused when the storage account exists.