### PR TITLE
Improve markup

### DIFF
--- a/src/main/webapp/help-imageReference.html
+++ b/src/main/webapp/help-imageReference.html
@@ -4,7 +4,7 @@
     </p>
     <br>
 
-    For example, with the <strong>image family:</strong>
+    For example, with the <strong>image family</strong>:
     <ol>
         <li>
             Ubuntu Server 16.04 LTS
@@ -37,5 +37,5 @@
     <p>
         The above examples are provided for reference purpose only and actual values supported by Azure may change at any time.
     </p>
-    Search for virtual machine <a href="http://azure.microsoft.com/en-us/marketplace/virtual-machines/all/" target="_blank">here</a>
+    Search for <a href="http://azure.microsoft.com/en-us/marketplace/virtual-machines/all/" target="_blank">virtual machines</a>.
 </div>


### PR DESCRIPTION
* colons generally do not belong in strong
* one should avoid using "here" as an anchor