### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
@@ -70,9 +70,9 @@
 
             <f:dropdownDescriptorSelector field="retentionStrategy" title="${%Retention_Strategy}" descriptors="${descriptor.azureVMRetentionStrategy}"/>
 
-            <f:entry title="${%shutdownOnIdle}" field="shutdownOnIdle"
-                     help="/plugin/azure-vm-agents/help-shutdownOnIdle.html">
-                <f:checkbox/>
+            <f:entry>
+                <f:checkbox title="${%shutdownOnIdle}" field="shutdownOnIdle"
+                     help="/plugin/azure-vm-agents/help-shutdownOnIdle.html" />
             </f:entry>
 
             <f:entry title="${%Usage}" field="usageMode" help="/plugin/azure-vm-agents/help-slaveMode.html">
@@ -88,16 +88,16 @@
                 </f:entry>
 
                 <f:section title="${%Pre_Installed_Tools}">
-                    <f:entry title="Install Git (Latest)" field="isInstallGit">
-                        <f:checkbox/>
+                    <f:entry>
+                        <f:checkbox title="Install Git (Latest)" field="isInstallGit" />
                     </f:entry>
 
-                    <f:entry title="Install Maven (V3.5.2)" field="isInstallMaven">
-                        <f:checkbox/>
+                    <f:entry>
+                        <f:checkbox title="Install Maven (V3.5.2)" field="isInstallMaven" />
                     </f:entry>
 
-                    <f:entry title="Install Docker" field="isInstallDocker">
-                        <f:checkbox/>
+                    <f:entry>
+                        <f:checkbox title="Install Docker" field="isInstallDocker" />
                     </f:entry>
                 </f:section>
             </ui:radioBlock>
@@ -145,9 +145,10 @@
                     <f:select/>
                 </f:entry>
 
-                <f:entry title="${%Pre_Install_Ssh}" field="preInstallSsh"
-                         help="/plugin/azure-vm-agents/help-preInstallSsh.html">
-                    <f:checkbox default="true"/>
+                <f:entry>
+                    <f:checkbox title="${%Pre_Install_Ssh}" field="preInstallSsh"
+                                help="/plugin/azure-vm-agents/help-preInstallSsh.html"
+                                default="true" />
                 </f:entry>
 
                 <f:section title="${%Initialization_Configuration}">
@@ -155,19 +156,21 @@
                         <f:textarea/>
                     </f:entry>
 
-                    <f:entry title="${%Execute_Init_Script_As_Root}" field="executeInitScriptAsRoot"
-                             help="/plugin/azure-vm-agents/help-executeInitScriptAsRoot.html">
-                        <f:checkbox default="true"/>
+                    <f:entry>
+                        <f:checkbox title="${%Execute_Init_Script_As_Root}" field="executeInitScriptAsRoot"
+                                    help="/plugin/azure-vm-agents/help-executeInitScriptAsRoot.html"
+                                    default="true" />
                     </f:entry>
 
-                    <f:entry title="${%Do_Not_Use_Machine_If_Init_Fails}" field="doNotUseMachineIfInitFails"
-                             help="/plugin/azure-vm-agents/help-doNotUseMachineIfInitFails.html">
-                        <f:checkbox default="true"/>
+                    <f:entry>
+                        <f:checkbox title="${%Do_Not_Use_Machine_If_Init_Fails}" field="doNotUseMachineIfInitFails"
+                                    help="/plugin/azure-vm-agents/help-doNotUseMachineIfInitFails.html"
+                                    default="true" />
                     </f:entry>
 
-                    <f:entry title="${%Enable_MSI}" field="enableMSI"
-                        help="/plugin/azure-vm-agents/help-enableMSI.html">
-                        <f:checkbox/>
+                    <f:entry>
+                        <f:checkbox title="${%Enable_MSI}" field="enableMSI"
+                                    help="/plugin/azure-vm-agents/help-enableMSI.html" />
                     </f:entry>
                 </f:section>
 
@@ -186,15 +189,15 @@
                         <f:textbox/>
                     </f:entry>
 
-                    <f:entry title="${%Use_Private_Ip}" field="usePrivateIP"
-                             help="/plugin/azure-vm-agents/help-agentPrivateIp.html">
-                        <f:checkbox default="false"/>
+                    <f:entry>
+                        <f:checkbox title="${%Use_Private_Ip}" field="usePrivateIP"
+                                    help="/plugin/azure-vm-agents/help-agentPrivateIp.html"
+                                    default="false" />
                     </f:entry>
 
                     <f:entry title="${%NSG_Name}" field="nsgName" help="/plugin/azure-vm-agents/help-nsgName.html">
                         <f:textbox/>
                     </f:entry>
-
 
                     <f:entry title="${%JVM_Options}" field="jvmOptions" help="/plugin/azure-vm-agents/help-jvmOptions.html">
                         <f:textbox/>
@@ -205,9 +208,9 @@
                         <f:textbox default="${descriptor.getDefaultNoOfExecutors()}"/>
                     </f:entry>
 
-                    <f:entry title="${%Template_Is_Disabled}" field="templateDisabled"
-                             help="/plugin/azure-vm-agents/help-templateDisabled.html">
-                        <f:checkbox/>
+                    <f:entry>
+                        <f:checkbox title="${%Template_Is_Disabled}" field="templateDisabled"
+                                    help="/plugin/azure-vm-agents/help-templateDisabled.html" />
                     </f:entry>
 
                     <f:entry title="${%Template_Status_Details}" field="templateStatusDetails"


### PR DESCRIPTION
[https://issues.jenkins-ci.org/browse/JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.

This supersedes #132 