### PR TITLE
Prevent agent with limit disk space to accept tasks

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudBaseRetentionStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudBaseRetentionStrategy.java
@@ -3,6 +3,7 @@ package com.microsoft.azure.vmagent;
 import hudson.model.Computer;
 import hudson.node_monitors.DiskSpaceMonitor;
 import hudson.node_monitors.DiskSpaceMonitorDescriptor;
+import hudson.slaves.OfflineCause;
 import hudson.slaves.RetentionStrategy;
 import jenkins.model.Jenkins;
 
@@ -38,7 +39,12 @@ public abstract class AzureVMCloudBaseRetentionStrategy extends RetentionStrateg
         DiskSpaceMonitorDescriptor.DiskSpace freeSpace = monitor.getFreeSpace(agent);
         long freeSpaceInMb = freeSpace.size / BYTES_IN_MB;
         if (freeSpaceInMb < FREE_SPACE_THRESHOLD_MB) {
-            agent.setAcceptingTasks(false);
+            agent.setTemporarilyOffline(true, OfflineCause.create(Messages._Limit_Disk_Space()));
+        } else {
+            if (agent.isOffline() && agent.getOfflineCauseReason().equals(Messages.Limit_Disk_Space())) {
+                agent.setTemporarilyOffline(false, null);
+            }
+
         }
     }
 }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
@@ -129,7 +129,7 @@ public class AzureVMCloudPoolRetentionStrategy extends AzureVMCloudBaseRetention
         }
     }
 
-    private static synchronized void checkPoolSizeAndDelete(AzureVMComputer agentComputer, int poolSize) {
+    private synchronized void checkPoolSizeAndDelete(AzureVMComputer agentComputer, int currentPoolSize) {
         int count = 0;
         List<Computer> computers = Arrays.asList(Jenkins.getInstance().getComputers());
         for (Computer computer : computers) {
@@ -143,11 +143,13 @@ public class AzureVMCloudPoolRetentionStrategy extends AzureVMCloudBaseRetention
             }
         }
 
-        if (count > poolSize) {
+        if (count > currentPoolSize) {
             LOGGER.log(Level.INFO, "Delete VM {0} for pool size exceed limit: {1}",
                     new Object[]{agentComputer, count});
             tryDeleteWhenIdle(agentComputer);
             return;
+        } else {
+            checkDiskSpace(agentComputer);
         }
     }
 

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudRetensionStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudRetensionStrategy.java
@@ -132,6 +132,8 @@ public class AzureVMCloudRetensionStrategy extends AzureVMCloudBaseRetentionStra
                     node.setCleanUpAction(CleanUpAction.DELETE, Messages._Failed_Initial_Shutdown_Or_Delete());
                 }
             }
+        } else {
+            checkDiskSpace(agentNode);
         }
         return 1;
     }

--- a/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
@@ -66,6 +66,7 @@ Agent_Failed_To_Connect=The agent failed to connect. The node has been marked fo
                        for the agent to connect to the master.
 Agent_Failed_Init_Script=The agent connected, but failed its initialization script.  The node has been marked for deletion.
 Shutdown_Agent_Failed_To_Revive=The previously shut down agent failed to start.
+Limit_Disk_Space=The agent has limit free disk space.
 
 # Post build action for deprovisioning
 Azure_Agent_Post_Build_Action=Perform an action if the job was performed on an Azure VM Agent.


### PR DESCRIPTION
For idle retention and pool retention strategies, if the agents do not need to be deleted, we should check if there are enough disk spaces on them. If the disk space is low, we prefer the agents not accept tasks.