### PR TITLE
Prevent creating again for existing resource group

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -996,6 +996,10 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         return retrieveAzureCloudReference().getResourceGroupName();
     }
 
+    public String getResourceGroupReferenceType() {
+        return retrieveAzureCloudReference().getResourceGroupReferenceType();
+    }
+
     public int getRetentionTimeInMin() {
         return retentionTimeInMin;
     }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -211,13 +211,16 @@ public final class AzureVMManagementServiceDelegate {
                         new Object[]{template.getResourceGroupName()});
                 throw new Exception("ResourceGroup Name is invalid");
             }
-            final String resourceGroupName = template.getResourceGroupName();
             LOGGER.log(Level.INFO,
                     "AzureVMManagementServiceDelegate: createDeployment:"
                             + " Creating a new deployment {0} with VM base name {1}",
                     new Object[]{deploymentName, vmBaseName});
+            final String resourceGroupName = template.getResourceGroupName();
+            final String resourceGroupReferenceType = template.getResourceGroupReferenceType();
 
-            createAzureResourceGroup(azureClient, locationName, resourceGroupName);
+            if (Constants.RESOURCE_GROUP_REFERENCE_TYPE_NEW.equals(resourceGroupReferenceType)) {
+                createAzureResourceGroup(azureClient, locationName, resourceGroupName);
+            }
             //For blob endpoint url in arm template, it's different based on different environments
             //So create StorageAccount and get suffix
             createStorageAccount(azureClient, storageAccountType, storageAccountName, locationName, resourceGroupName);
@@ -727,11 +730,14 @@ public final class AzureVMManagementServiceDelegate {
         String targetStorageAccount = template.getStorageAccountName();
         String targetStorageAccountType = template.getStorageAccountType();
         String resourceGroupName = template.getResourceGroupName();
+        String resourceGroupReferenceType = template.getResourceGroupReferenceType();
         String location = template.getLocation();
 
         //make sure the resource group and storage account exist
         try {
-            createAzureResourceGroup(azureClient, location, resourceGroupName);
+            if (Constants.RESOURCE_GROUP_REFERENCE_TYPE_NEW.equals(resourceGroupReferenceType)) {
+                createAzureResourceGroup(azureClient, location, resourceGroupName);
+            }
             createStorageAccount(
                     azureClient, targetStorageAccountType, targetStorageAccount, location, resourceGroupName);
         } catch (Exception e) {

--- a/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
@@ -124,6 +124,12 @@ public final class Constants {
     public static final String UBUNTU_1604_LTS = "Ubuntu 16.04 LTS";
 
     /**
+     * ResourceGroup reference type.
+     */
+    public static final String RESOURCE_GROUP_REFERENCE_TYPE_NEW = "new";
+    public static final String RESOURCE_GROUP_REFERENCE_TYPE_EXISTING = "existing";
+
+    /**
      * Default Image Properties.
      */
     public static final String DEFAULT_IMAGE_ID = "defaultImageId";

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
@@ -89,6 +89,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
         when(templateMock.getLocation()).thenReturn(testEnv.azureLocation);
         when(templateMock.getInitScript()).thenReturn(writtenData);
         when(templateMock.getStorageAccountType()).thenReturn(SkuName.STANDARD_LRS.toString());
+        when(templateMock.getResourceGroupReferenceType()).thenReturn(testEnv.azureResourceGroupReferenceType);
         AzureVMCloud cloudMock = mock(AzureVMCloud.class);
         when(cloudMock.getCloudName()).thenReturn("testCloudName");
         when(templateMock.retrieveAzureCloudReference()).thenReturn(cloudMock);

--- a/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
@@ -104,6 +104,7 @@ public class IntegrationTest {
         public String availabilityType;
         public String availabilitySet;
         public final String azureResourceGroup;
+        public final String azureResourceGroupReferenceType;
         public final String azureStorageAccountName;
         public final String azureStorageAccountType;
         public final String azureImageId;
@@ -138,6 +139,7 @@ public class IntegrationTest {
 
             azureLocation = TestEnvironment.loadFromEnv("VM_AGENTS_TEST_DEFAULT_LOCATION", "East US");
             azureResourceGroup = TestEnvironment.loadFromEnv("VM_AGENTS_TEST_DEFAULT_RESOURCE_GROUP_PREFIX", "vmagents-tst") + "-" + TestEnvironment.GenerateRandomString(16);
+            azureResourceGroupReferenceType = TestEnvironment.loadFromEnv("VM_AGENTS_TEST_DEFAULT_RESOURCE_REFERENCE_TYPE", Constants.RESOURCE_GROUP_REFERENCE_TYPE_NEW);
             azureStorageAccountName = TestEnvironment.loadFromEnv("VM_AGENTS_TEST_DEFAULT_STORAGE_NAME_PREFIX", "vmtst") + TestEnvironment.GenerateRandomString(19);
             azureStorageAccountType = SkuName.STANDARD_LRS.toString();
             azureImageId = TestEnvironment.loadFromEnv("VM_AGENTS_TEST_DEFAULT_IMAGE_ID", "");
@@ -345,6 +347,7 @@ public class IntegrationTest {
         AzureVMCloud cloudMock = mock(AzureVMCloud.class);
         when(cloudMock.getCloudName()).thenReturn("testCloud");
         when(templateMock.getResourceGroupName()).thenReturn(testEnv.azureResourceGroup);
+        when(templateMock.getResourceGroupReferenceType()).thenReturn(testEnv.azureResourceGroupReferenceType);
         when(templateMock.getStorageAccountName()).thenReturn(testEnv.azureStorageAccountName);
         when(templateMock.getLocation()).thenReturn(testEnv.azureLocation);
         when(templateMock.getAvailabilityType()).thenReturn(new AzureVMAgentTemplate.AvailabilityTypeClass(testEnv.availabilitySet));


### PR DESCRIPTION
[JENKINS-57414](https://issues.jenkins-ci.org/browse/JENKINS-57414)

This may not be a good fix, need some discussion here.

For the legacy design here, users can choose to create a new resource group or use an existing one. And each time we provision a new agent, it will try to create a resource group with the agent's location which may cause conflicts for `The Resource group already exists in location '****'`.

This PR could fix bugs for existing resource group. But when user choose creating a new resource group, the location conflicts issue still exists. If we check before we create a new resource group, and there is already an existing resource group with the same name as the user wanted, user may miss this and use others' resource group.