### PR TITLE
Add tag for resoureces created by this plugin

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -2412,6 +2412,7 @@ public final class AzureVMManagementServiceDelegate {
             azureClient.resourceGroups()
                     .define(resourceGroupName)
                     .withRegion(locationName)
+                    .withTag(Constants.AZURE_JENKINS_TAG_NAME, Constants.AZURE_JENKINS_TAG_VALUE)
                     .create();
         } catch (Exception e) {
             throw AzureCloudException.create(
@@ -2441,10 +2442,12 @@ public final class AzureVMManagementServiceDelegate {
             // Reuse existing to prevent failure.
 
             if (azureClient.storageAccounts().getByResourceGroup(resourceGroupName, targetStorageAccount) == null) {
+                SkuName skuName = SkuName.fromString(targetStorageAccountType);
                 azureClient.storageAccounts().define(targetStorageAccount)
                         .withRegion(location)
                         .withExistingResourceGroup(resourceGroupName)
-                        .withSku(SkuName.fromString(targetStorageAccountType))
+                        .withTag(Constants.AZURE_JENKINS_TAG_NAME, Constants.AZURE_JENKINS_TAG_VALUE)
+                        .withSku(StorageAccountSkuType.fromSkuName(skuName))
                         .create();
             }
         } catch (Exception e) {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -217,10 +217,11 @@ public final class AzureVMManagementServiceDelegate {
                             + " Creating a new deployment {0} with VM base name {1}",
                     new Object[]{deploymentName, vmBaseName});
 
-            createAzureResourceGroup(azureClient, locationName, resourceGroupName);
+            String cloudName = template.retrieveAzureCloudReference().getCloudName();
+            createAzureResourceGroup(azureClient, locationName, resourceGroupName, cloudName);
             //For blob endpoint url in arm template, it's different based on different environments
             //So create StorageAccount and get suffix
-            createStorageAccount(azureClient, storageAccountType, storageAccountName, locationName, resourceGroupName);
+            createStorageAccount(azureClient, storageAccountType, storageAccountName, locationName, resourceGroupName, template.getTemplateName());
             StorageAccount storageAccount = getStorageAccount(azureClient, storageAccountName, resourceGroupName);
             String blobEndpointSuffix = getBlobEndpointSuffixForTemplate(storageAccount);
 
@@ -300,7 +301,7 @@ public final class AzureVMManagementServiceDelegate {
             putVariable(tmp, "location", locationName);
             putVariable(tmp, "jenkinsTag", Constants.AZURE_JENKINS_TAG_VALUE);
             putVariable(tmp, "resourceTag", deploymentRegistrar.getDeploymentTag().get());
-            putVariable(tmp, "cloudTag", template.retrieveAzureCloudReference().getCloudName());
+            putVariable(tmp, "cloudTag", cloudName);
 
             // add purchase plan for image if needed in reference configuration
             // Image Configuration has four choices, isBasic->Built-in Image, useCustomImage->Custom User Image
@@ -488,7 +489,7 @@ public final class AzureVMManagementServiceDelegate {
 
             // Register the deployment for cleanup
             deploymentRegistrar.registerDeployment(
-                    template.retrieveAzureCloudReference().getCloudName(), template.getResourceGroupName(), deploymentName, scriptUri);
+                    cloudName, template.getResourceGroupName(), deploymentName, scriptUri);
             // Create the deployment
             azureClient.deployments().define(deploymentName)
                     .withExistingResourceGroup(template.getResourceGroupName())
@@ -731,9 +732,10 @@ public final class AzureVMManagementServiceDelegate {
 
         //make sure the resource group and storage account exist
         try {
-            createAzureResourceGroup(azureClient, location, resourceGroupName);
+            AzureVMCloud azureVMCloud = template.retrieveAzureCloudReference();
+            createAzureResourceGroup(azureClient, location, resourceGroupName, azureVMCloud.getCloudName());
             createStorageAccount(
-                    azureClient, targetStorageAccountType, targetStorageAccount, location, resourceGroupName);
+                    azureClient, targetStorageAccountType, targetStorageAccount, location, resourceGroupName, template.getTemplateName());
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Got exception when checking the storage account for custom scripts", e);
         }
@@ -2407,12 +2409,14 @@ public final class AzureVMManagementServiceDelegate {
      * @param resourceGroupName
      */
     private void createAzureResourceGroup(
-            Azure azureClient, String locationName, String resourceGroupName) throws AzureCloudException {
+            Azure azureClient, String locationName, String resourceGroupName,
+            String cloudName) throws AzureCloudException {
         try {
             azureClient.resourceGroups()
                     .define(resourceGroupName)
                     .withRegion(locationName)
                     .withTag(Constants.AZURE_JENKINS_TAG_NAME, Constants.AZURE_JENKINS_TAG_VALUE)
+                    .withTag(Constants.AZURE_CLOUD_TAG_NAME, cloudName)
                     .create();
         } catch (Exception e) {
             throw AzureCloudException.create(
@@ -2436,7 +2440,8 @@ public final class AzureVMManagementServiceDelegate {
             String targetStorageAccountType,
             String targetStorageAccount,
             String location,
-            String resourceGroupName) throws AzureCloudException {
+            String resourceGroupName,
+            String templateName) throws AzureCloudException {
         try {
             // Get storage account before creating.
             // Reuse existing to prevent failure.
@@ -2447,6 +2452,7 @@ public final class AzureVMManagementServiceDelegate {
                         .withRegion(location)
                         .withExistingResourceGroup(resourceGroupName)
                         .withTag(Constants.AZURE_JENKINS_TAG_NAME, Constants.AZURE_JENKINS_TAG_VALUE)
+                        .withTag(Constants.AZURE_TEMPLATE_TAG_NAME, templateName)
                         .withSku(StorageAccountSkuType.fromSkuName(skuName))
                         .create();
             }

--- a/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
@@ -232,6 +232,8 @@ public final class Constants {
 
     public static final String AZURE_CLOUD_TAG_NAME = "JenkinsCloudTag";
 
+    public static final String AZURE_TEMPLATE_TAG_NAME = "JenkinsTemplateTag";
+
     public static final long AZURE_DEPLOYMENT_TIMEOUT = 2 * 60 * 60; //in seconds
 
     public static final String VERSION_LATEST = "latest";


### PR DESCRIPTION
Follow up action of #149. 

When this plugin creates resources like resource group and storage account, it better adds specific tags to them. This can help detect whether there is conflicts with other resources.

> Also update an deprecated parameter for storage account, only add more wrapper, no logic changes.