### PR TITLE
Fix UAMI

### DIFF
--- a/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
@@ -57,7 +57,7 @@
       }
     },
     {
-      "apiVersion": "2018-04-01",
+      "apiVersion": "2019-03-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "location": "[variables('location')]",
@@ -74,7 +74,7 @@
           "vmSize": "[variables('vmSize')]"
         },
         "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
+          "computerName": "[concat(variables('vmName'), copyIndex())]",
           "adminUsername": "[variables('adminUsername')]",
           "adminPassword": "[variables('adminPassword')]"
         },


### PR DESCRIPTION
Prior to this fix this exception was occurring:
```
SEVERE: Failure creating provisioned agent 'team1-eaed00'
com.microsoft.azure.vmagent.exceptions.AzureCloudException: AzureVMCloud: createProvisionedAgent: Deployment Failed: Microsoft.Compute/virtualMachines:team1-eaed00 - BadRequest - {error={code=InvalidParameter, message=ResourceIdentity property userAssignedIdentities is not supported on this API version., target=resourceIdentity.userAssignedIdentities}}
	at com.microsoft.azure.vmagent.exceptions.AzureCloudException.create(AzureCloudException.java:37)
	at com.microsoft.azure.vmagent.AzureVMCloud.createProvisionedAgent(AzureVMCloud.java:572)
```
I mustn't have test it properly in the previous PR when the ARM template was inlined 🤦‍♂ 