### PR TITLE
Sync JSON to make them diffable

### DIFF
--- a/src/main/resources/customImageTemplate.json
+++ b/src/main/resources/customImageTemplate.json
@@ -14,7 +14,7 @@
         "storageAccountContainerName": "[concat('jnk',uniqueString(resourceGroup().id, deployment().name))]",
         "storageAccountType": "Standard_LRS",
         "jenkinsTag": "ManagedByAzureVMAgents",
-        "resourceTag": "AzureJenkinsMasterId",
+        "resourceTag": "AzureJenkins",
         "blobEndpointSuffix": ".blob.core.windows.net/"
     },
     "resources": [
@@ -63,7 +63,7 @@
                     "vmSize": "[variables('vmSize')]"
                 },
                 "osProfile": {
-                    "computername": "[concat(variables('vmName'), copyIndex())]",
+                    "computerName": "[concat(variables('vmName'), copyIndex())]",
                     "adminUsername": "[variables('adminUsername')]",
                     "adminPassword": "[variables('adminPassword')]"
                 },

--- a/src/main/resources/customImageTemplateWithManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithManagedDisk.json
@@ -1,116 +1,116 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-  "contentVersion": "2.0.0.0",
-  "parameters": {},
-  "variables": {
-    "virtualNetworkName": "",
-    "virtualNetworkResourceGroupName": "",
-    "subnetName": "",
-    "nsgName": "",
-    "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-    "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "publicIPAddressType": "Dynamic",
-    "storageAccountContainerName": "[concat('jnk',uniqueString(resourceGroup().id, deployment().name))]",
-    "storageAccountType": "Standard_LRS",
-    "jenkinsTag": "ManagedByAzureVMAgents",
-    "resourceTag": "AzureJenkinsMasterId",
-    "blobEndpointSuffix": ".blob.core.windows.net/"
-  },
-  "resources": [
-    {
-      "apiVersion": "2018-10-01",
-      "type": "Microsoft.Compute/images",
-      "name": "[concat(variables('vmName'), 'Image')]",
-      "location": "[variables('location')]",
-      "properties": {
-        "storageProfile": {
-          "osDisk": {
-            "osState": "Generalized",
-            "osType": "[variables('osType')]",
-            "blobUri": "[variables('image')]",
-            "storageAccountType": "[variables('storageAccountType')]"
-          }
-        }
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json",
+    "contentVersion": "2.0.0.0",
+    "parameters": {},
+    "variables": {
+        "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
+        "subnetName": "",
+        "nsgName": "",
+        "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+        "publicIPAddressType": "Dynamic",
+        "storageAccountContainerName": "[concat('jnk',uniqueString(resourceGroup().id, deployment().name))]",
+        "storageAccountType": "Standard_LRS",
+        "jenkinsTag": "ManagedByAzureVMAgents",
+        "resourceTag": "AzureJenkins",
+        "blobEndpointSuffix": ".blob.core.windows.net/"
     },
-    {
-      "apiVersion": "2019-04-01",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
+    "resources": [
+        {
+            "apiVersion": "2018-10-01",
+            "type": "Microsoft.Compute/images",
+            "name": "[concat(variables('vmName'), 'Image')]",
+            "location": "[variables('location')]",
             "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('subnetRef')]"
-              }
+                "storageProfile": {
+                    "osDisk": {
+                        "osState": "Generalized",
+                        "osType": "[variables('osType')]",
+                        "blobUri": "[variables('image')]",
+                        "storageAccountType": "[variables('storageAccountType')]"
+                    }
+                }
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
-          }
-        ]
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
-    },
-    {
-      "apiVersion": "2019-03-01",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(variables('vmName'), copyIndex())]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]",
-        "[concat('Microsoft.Compute/images/', variables('vmName'), 'Image')]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
         },
-        "osProfile": {
-          "computerName": "[concat(variables('vmName'), copyIndex())]",
-          "adminUsername": "[variables('adminUsername')]",
-          "adminPassword": "[variables('adminPassword')]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "id": "[resourceId('Microsoft.Compute/images', concat(variables('vmName'), 'Image'))]"
-          },
-          "osDisk": {
-            "createOption": "FromImage",
-            "managedDisk": {
-              "storageAccountType": "[variables('storageAccountType')]"
+        {
+            "apiVersion": "2019-04-01",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
-          }
         },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+        {
+            "apiVersion": "2019-03-01",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[concat(variables('vmName'), copyIndex())]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]",
+                "[concat('Microsoft.Compute/images/', variables('vmName'), 'Image')]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat(variables('vmName'), copyIndex())]",
+                    "adminUsername": "[variables('adminUsername')]",
+                    "adminPassword": "[variables('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "id": "[resourceId('Microsoft.Compute/images', concat(variables('vmName'), 'Image'))]"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "[variables('storageAccountType')]"
+                        }
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                        }
+                    ]
+                }
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
-          ]
         }
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
-    }
-  ]
+    ]
 }

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json",
     "contentVersion": "2.0.0.0",
     "parameters": {
         "storageAccountKey": {
@@ -71,7 +71,7 @@
                     "vmSize": "[variables('vmSize')]"
                 },
                 "osProfile": {
-                    "computername": "[concat(variables('vmName'), copyIndex())]",
+                    "computerName": "[concat(variables('vmName'), copyIndex())]",
                     "adminUsername": "[variables('adminUsername')]",
                     "adminPassword": "[variables('adminPassword')]"
                 },

--- a/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
@@ -1,151 +1,151 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-  "contentVersion": "2.0.0.0",
-  "parameters": {
-    "storageAccountKey": {
-      "type": "securestring"
-    }
-  },
-  "variables": {
-    "virtualNetworkName": "",
-    "virtualNetworkResourceGroupName": "",
-    "subnetName": "",
-    "nsgName": "",
-    "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-    "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "publicIPAddressType": "Dynamic",
-    "storageAccountContainerName": "[concat('jnk',uniqueString(resourceGroup().id, deployment().name))]",
-    "storageAccountType": "Standard_LRS",
-    "startupScriptURI": "",
-    "startupScriptName": "",
-    "jenkinsServerURL": "",
-    "clientSecrets": [],
-    "jenkinsTag": "ManagedByAzureVMAgents",
-    "resourceTag": "AzureJenkins",
-    "blobEndpointSuffix": ".blob.core.windows.net/"
-  },
-  "resources": [
-    {
-      "apiVersion": "2018-10-01",
-      "type": "Microsoft.Compute/images",
-      "name": "[concat(variables('vmName'), 'Image')]",
-      "location": "[variables('location')]",
-      "properties": {
-        "storageProfile": {
-          "osDisk": {
-            "osState": "Generalized",
-            "osType": "[variables('osType')]",
-            "blobUri": "[variables('image')]",
-            "storageAccountType": "[variables('storageAccountType')]"
-          }
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json",
+    "contentVersion": "2.0.0.0",
+    "parameters": {
+        "storageAccountKey": {
+            "type": "securestring"
         }
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
     },
-    {
-      "apiVersion": "2019-04-01",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
-            "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('subnetRef')]"
-              }
-            }
-          }
-        ]
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
+    "variables": {
+        "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
+        "subnetName": "",
+        "nsgName": "",
+        "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+        "publicIPAddressType": "Dynamic",
+        "storageAccountContainerName": "[concat('jnk',uniqueString(resourceGroup().id, deployment().name))]",
+        "storageAccountType": "Standard_LRS",
+        "startupScriptURI": "",
+        "startupScriptName": "",
+        "jenkinsServerURL": "",
+        "clientSecrets": [],
+        "jenkinsTag": "ManagedByAzureVMAgents",
+        "resourceTag": "AzureJenkins",
+        "blobEndpointSuffix": ".blob.core.windows.net/"
     },
-    {
-      "apiVersion": "2019-03-01",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(variables('vmName'), copyIndex())]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]",
-        "[concat('Microsoft.Compute/images/', variables('vmName'), 'Image')]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
-        },
-        "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
-          "adminUsername": "[variables('adminUsername')]",
-          "adminPassword": "[variables('adminPassword')]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "id": "[resourceId('Microsoft.Compute/images', concat(variables('vmName'), 'Image'))]"
-          },
-          "osDisk": {
-            "createOption": "FromImage",
-            "managedDisk": {
-              "storageAccountType": "[variables('storageAccountType')]"
-            }
-          }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
-            }
-          ]
-        }
-      },
-      "resources": [
+    "resources": [
         {
-          "type": "extensions",
-          "name": "[concat('customScript', variables('vmName'), copyIndex())]",
-          "apiVersion": "2019-03-01",
-          "location": "[variables('location')]",
-          "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
-          ],
-          "properties": {
-            "publisher": "Microsoft.Compute",
-            "type": "CustomScriptExtension",
-            "typeHandlerVersion": "1.7",
-            "autoUpgradeMinorVersion": true,
-            "settings": {
-              "fileUris": [
-                "[variables('startupScriptURI')]"
-              ],
-              "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+            "apiVersion": "2018-10-01",
+            "type": "Microsoft.Compute/images",
+            "name": "[concat(variables('vmName'), 'Image')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "storageProfile": {
+                    "osDisk": {
+                        "osState": "Generalized",
+                        "osType": "[variables('osType')]",
+                        "blobUri": "[variables('image')]",
+                        "storageAccountType": "[variables('storageAccountType')]"
+                    }
+                }
             },
-            "protectedSettings": {
-              "storageAccountName": "[variables('storageAccountName')]",
-              "storageAccountKey": "[parameters('storageAccountKey')]"
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
-          }
+        },
+        {
+            "apiVersion": "2019-04-01",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
+            }
+        },
+        {
+            "apiVersion": "2019-03-01",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[concat(variables('vmName'), copyIndex())]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]",
+                "[concat('Microsoft.Compute/images/', variables('vmName'), 'Image')]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat(variables('vmName'), copyIndex())]",
+                    "adminUsername": "[variables('adminUsername')]",
+                    "adminPassword": "[variables('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "id": "[resourceId('Microsoft.Compute/images', concat(variables('vmName'), 'Image'))]"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "[variables('storageAccountType')]"
+                        }
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                        }
+                    ]
+                }
+            },
+            "resources": [
+                {
+                    "type": "extensions",
+                    "name": "[concat('customScript', variables('vmName'), copyIndex())]",
+                    "apiVersion": "2019-03-01",
+                    "location": "[variables('location')]",
+                    "dependsOn": [
+                        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
+                    ],
+                    "properties": {
+                        "publisher": "Microsoft.Compute",
+                        "type": "CustomScriptExtension",
+                        "typeHandlerVersion": "1.7",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                            "fileUris": [
+                                "[variables('startupScriptURI')]"
+                            ],
+                            "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+                        },
+                        "protectedSettings": {
+                            "storageAccountName": "[variables('storageAccountName')]",
+                            "storageAccountKey": "[parameters('storageAccountKey')]"
+                        }
+                    }
+                }
+            ],
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
+            }
         }
-      ],
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
-    }
-  ]
+    ]
 }

--- a/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
@@ -1,111 +1,111 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-  "contentVersion": "2.0.0.0",
-  "parameters": {},
-  "variables": {
-    "virtualNetworkName": "",
-    "virtualNetworkResourceGroupName": "",
-    "subnetName": "",
-    "nsgName": "",
-    "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-    "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "publicIPAddressType": "Dynamic",
-    "storageAccountContainerName": "vhds",
-    "storageAccountType": "Standard_LRS",
-    "jenkinsTag": "ManagedByAzureVMAgents",
-    "resourceTag": "AzureJenkins",
-    "cloudTag": "",
-    "blobEndpointSuffix": ".blob.core.windows.net/"
-  },
-  "resources": [
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('storageAccountName')]",
-      "apiVersion": "2016-01-01",
-      "location": "[variables('location')]",
-      "sku": {
-        "name": "[variables('storageAccountType')]"
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json",
+    "contentVersion": "2.0.0.0",
+    "parameters": {},
+    "variables": {
+        "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
+        "subnetName": "",
+        "nsgName": "",
+        "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+        "publicIPAddressType": "Dynamic",
+        "storageAccountContainerName": "vhds",
+        "storageAccountType": "Standard_LRS",
+        "jenkinsTag": "ManagedByAzureVMAgents",
+        "resourceTag": "AzureJenkins",
+        "cloudTag": "",
+        "blobEndpointSuffix": ".blob.core.windows.net/"
     },
-    {
-      "apiVersion": "2019-04-01",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
+    "resources": [
+        {
+            "apiVersion": "2016-01-01",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountName')]",
+            "location": "[variables('location')]",
+            "sku": {
+                "name": "[variables('storageAccountType')]"
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
+            }
+        },
+        {
+            "apiVersion": "2019-04-01",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [],
             "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('subnetRef')]"
-              }
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
-          }
-        ]
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
-    },
-    {
-      "apiVersion": "2019-03-01",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(variables('vmName'), copyIndex())]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
-        "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
         },
-        "osProfile": {
-          "computerName": "[concat(variables('vmName'), copyIndex())]",
-          "adminUsername": "[variables('adminUsername')]",
-          "adminPassword": "[variables('adminPassword')]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "id": "[variables('imageID')]"
-          },
-          "osDisk": {
-            "createOption": "FromImage",
-            "managedDisk": {
-              "storageAccountType": "[variables('storageAccountType')]"
+        {
+            "apiVersion": "2019-03-01",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[concat(variables('vmName'), copyIndex())]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat(variables('vmName'), copyIndex())]",
+                    "adminUsername": "[variables('adminUsername')]",
+                    "adminPassword": "[variables('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "id": "[variables('imageId')]"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "[variables('storageAccountType')]"
+                        }
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                        }
+                    ]
+                }
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]",
+                "JenkinsCloudTag": "[variables('cloudTag')]"
             }
-          }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
-            }
-          ]
         }
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]",
-        "JenkinsCloudTag": "[variables('cloudTag')]"
-      }
-    }
-  ]
+    ]
 }

--- a/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
@@ -1,146 +1,146 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-  "contentVersion": "2.0.0.0",
-  "parameters": {
-    "storageAccountKey": {
-      "type": "securestring"
-    }
-  },
-  "variables": {
-    "virtualNetworkName": "",
-    "virtualNetworkResourceGroupName": "",
-    "subnetName": "",
-    "nsgName": "",
-    "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-    "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "publicIPAddressType": "Dynamic",
-    "storageAccountContainerName": "vhds",
-    "storageAccountType": "Standard_LRS",
-    "startupScriptURI": "",
-    "startupScriptName": "",
-    "jenkinsServerURL": "",
-    "clientSecrets": [],
-    "jenkinsTag": "ManagedByAzureVMAgents",
-    "resourceTag": "AzureJenkins",
-    "cloudTag": "",
-    "blobEndpointSuffix": ".blob.core.windows.net/"
-  },
-  "resources": [
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('storageAccountName')]",
-      "apiVersion": "2016-01-01",
-      "location": "[variables('location')]",
-      "sku": {
-        "name": "[variables('storageAccountType')]"
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
-    },
-    {
-      "apiVersion": "2019-04-01",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
-            "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('subnetRef')]"
-              }
-            }
-          }
-        ]
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
-    },
-    {
-      "apiVersion": "2019-03-01",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(variables('vmName'), copyIndex())]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
-        "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
-        },
-        "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
-          "adminUsername": "[variables('adminUsername')]",
-          "adminPassword": "[variables('adminPassword')]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "id": "[variables('imageId')]"
-          },
-          "osDisk": {
-            "createOption": "FromImage",
-            "managedDisk": {
-              "storageAccountType": "[variables('storageAccountType')]"
-            }
-          }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
-            }
-          ]
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json",
+    "contentVersion": "2.0.0.0",
+    "parameters": {
+        "storageAccountKey": {
+            "type": "securestring"
         }
-      },
-      "resources": [
+    },
+    "variables": {
+        "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
+        "subnetName": "",
+        "nsgName": "",
+        "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+        "publicIPAddressType": "Dynamic",
+        "storageAccountContainerName": "vhds",
+        "storageAccountType": "Standard_LRS",
+        "startupScriptURI": "",
+        "startupScriptName": "",
+        "jenkinsServerURL": "",
+        "clientSecrets": [],
+        "jenkinsTag": "ManagedByAzureVMAgents",
+        "resourceTag": "AzureJenkins",
+        "cloudTag": "",
+        "blobEndpointSuffix": ".blob.core.windows.net/"
+    },
+    "resources": [
         {
-          "type": "extensions",
-          "name": "[concat('customScript', variables('vmName'), copyIndex())]",
-          "apiVersion": "2019-03-01",
-          "location": "[variables('location')]",
-          "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
-          ],
-          "properties": {
-            "publisher": "Microsoft.Compute",
-            "type": "CustomScriptExtension",
-            "typeHandlerVersion": "1.7",
-            "autoUpgradeMinorVersion": true,
-            "settings": {
-              "fileUris": [
-                "[variables('startupScriptURI')]"
-              ],
-              "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+            "apiVersion": "2016-01-01",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountName')]",
+            "location": "[variables('location')]",
+            "sku": {
+                "name": "[variables('storageAccountType')]"
             },
-            "protectedSettings": {
-              "storageAccountName": "[variables('storageAccountName')]",
-              "storageAccountKey": "[parameters('storageAccountKey')]"
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
-          }
+        },
+        {
+            "apiVersion": "2019-04-01",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
+            }
+        },
+        {
+            "apiVersion": "2019-03-01",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[concat(variables('vmName'), copyIndex())]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat(variables('vmName'), copyIndex())]",
+                    "adminUsername": "[variables('adminUsername')]",
+                    "adminPassword": "[variables('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "id": "[variables('imageId')]"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "[variables('storageAccountType')]"
+                        }
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                        }
+                    ]
+                }
+            },
+            "resources": [
+                {
+                    "type": "extensions",
+                    "name": "[concat('customScript', variables('vmName'), copyIndex())]",
+                    "apiVersion": "2019-03-01",
+                    "location": "[variables('location')]",
+                    "dependsOn": [
+                        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
+                    ],
+                    "properties": {
+                        "publisher": "Microsoft.Compute",
+                        "type": "CustomScriptExtension",
+                        "typeHandlerVersion": "1.7",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                            "fileUris": [
+                                "[variables('startupScriptURI')]"
+                            ],
+                            "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+                        },
+                        "protectedSettings": {
+                            "storageAccountName": "[variables('storageAccountName')]",
+                            "storageAccountKey": "[parameters('storageAccountKey')]"
+                        }
+                    }
+                }
+            ],
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]",
+                "JenkinsCloudTag": "[variables('cloudTag')]"
+            }
         }
-      ],
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]",
-        "JenkinsCloudTag": "[variables('cloudTag')]"
-      }
-    }
-  ]
+    ]
 }

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json",
     "contentVersion": "2.0.0.0",
     "parameters": {},
     "variables": {
@@ -20,9 +20,9 @@
     },
     "resources": [
         {
+            "apiVersion": "2016-01-01",
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
-            "apiVersion": "2016-01-01",
             "location": "[variables('location')]",
             "sku": {
                 "name": "[variables('storageAccountType')]"
@@ -78,7 +78,7 @@
                     "vmSize": "[variables('vmSize')]"
                 },
                 "osProfile": {
-                    "computername": "[concat(variables('vmName'), copyIndex())]",
+                    "computerName": "[concat(variables('vmName'), copyIndex())]",
                     "adminUsername": "[variables('adminUsername')]",
                     "adminPassword": "[variables('adminPassword')]"
                 },

--- a/src/main/resources/referenceImageTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithManagedDisk.json
@@ -1,114 +1,114 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-  "contentVersion": "2.0.0.0",
-  "parameters": {},
-  "variables": {
-    "virtualNetworkName": "",
-    "virtualNetworkResourceGroupName": "",
-    "subnetName": "",
-    "nsgName": "",
-    "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-    "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "publicIPAddressType": "Dynamic",
-    "storageAccountContainerName": "vhds",
-    "storageAccountType": "Standard_LRS",
-    "jenkinsTag": "ManagedByAzureVMAgents",
-    "resourceTag": "AzureJenkins",
-    "cloudTag": "",
-    "blobEndpointSuffix": ".blob.core.windows.net/"
-  },
-  "resources": [
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('storageAccountName')]",
-      "apiVersion": "2016-01-01",
-      "location": "[variables('location')]",
-      "sku": {
-        "name": "[variables('storageAccountType')]"
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json",
+    "contentVersion": "2.0.0.0",
+    "parameters": {},
+    "variables": {
+        "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
+        "subnetName": "",
+        "nsgName": "",
+        "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+        "publicIPAddressType": "Dynamic",
+        "storageAccountContainerName": "vhds",
+        "storageAccountType": "Standard_LRS",
+        "jenkinsTag": "ManagedByAzureVMAgents",
+        "resourceTag": "AzureJenkins",
+        "cloudTag": "",
+        "blobEndpointSuffix": ".blob.core.windows.net/"
     },
-    {
-      "apiVersion": "2019-04-01",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
+    "resources": [
+        {
+            "apiVersion": "2016-01-01",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountName')]",
+            "location": "[variables('location')]",
+            "sku": {
+                "name": "[variables('storageAccountType')]"
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
+            }
+        },
+        {
+            "apiVersion": "2019-04-01",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [],
             "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('subnetRef')]"
-              }
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
-          }
-        ]
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
-    },
-    {
-      "apiVersion": "2019-03-01",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(variables('vmName'), copyIndex())]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
-        "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
         },
-        "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
-          "adminUsername": "[variables('adminUsername')]",
-          "adminPassword": "[variables('adminPassword')]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "publisher": "[variables('imagePublisher')]",
-            "offer": "[variables('imageOffer')]",
-            "sku": "[variables('imageSku')]",
-            "version": "[variables('imageVersion')]"
-          },
-          "osDisk": {
-            "createOption": "FromImage",
-            "managedDisk": {
-              "storageAccountType": "[variables('storageAccountType')]"
+        {
+            "apiVersion": "2019-03-01",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[concat(variables('vmName'), copyIndex())]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat(variables('vmName'), copyIndex())]",
+                    "adminUsername": "[variables('adminUsername')]",
+                    "adminPassword": "[variables('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('imagePublisher')]",
+                        "offer": "[variables('imageOffer')]",
+                        "sku": "[variables('imageSku')]",
+                        "version": "[variables('imageVersion')]"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "[variables('storageAccountType')]"
+                        }
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                        }
+                    ]
+                }
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]",
+                "JenkinsCloudTag": "[variables('cloudTag')]"
             }
-          }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
-            }
-          ]
         }
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]",
-        "JenkinsCloudTag": "[variables('cloudTag')]"
-      }
-    }
-  ]
+    ]
 }

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json",
     "contentVersion": "2.0.0.0",
     "parameters": {
         "storageAccountKey": {
@@ -28,9 +28,9 @@
     },
     "resources": [
         {
+            "apiVersion": "2016-01-01",
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
-            "apiVersion": "2016-01-01",
             "location": "[variables('location')]",
             "sku": {
                 "name": "[variables('storageAccountType')]"
@@ -86,7 +86,7 @@
                     "vmSize": "[variables('vmSize')]"
                 },
                 "osProfile": {
-                    "computername": "[concat(variables('vmName'), copyIndex())]",
+                    "computerName": "[concat(variables('vmName'), copyIndex())]",
                     "adminUsername": "[variables('adminUsername')]",
                     "adminPassword": "[variables('adminPassword')]"
                 },

--- a/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
@@ -1,149 +1,149 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-  "contentVersion": "2.0.0.0",
-  "parameters": {
-    "storageAccountKey": {
-      "type": "securestring"
-    }
-  },
-  "variables": {
-    "virtualNetworkName": "",
-    "virtualNetworkResourceGroupName": "",
-    "subnetName": "",
-    "nsgName": "",
-    "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
-    "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "publicIPAddressType": "Dynamic",
-    "storageAccountContainerName": "vhds",
-    "storageAccountType": "Standard_LRS",
-    "startupScriptURI": "",
-    "startupScriptName": "",
-    "jenkinsServerURL": "",
-    "clientSecrets": [],
-    "jenkinsTag": "ManagedByAzureVMAgents",
-    "resourceTag": "AzureJenkins",
-    "cloudTag": "",
-    "blobEndpointSuffix": ".blob.core.windows.net/"
-  },
-  "resources": [
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('storageAccountName')]",
-      "apiVersion": "2016-01-01",
-      "location": "[variables('location')]",
-      "sku": {
-        "name": "[variables('storageAccountType')]"
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
-    },
-    {
-      "apiVersion": "2019-04-01",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
-            "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('subnetRef')]"
-              }
-            }
-          }
-        ]
-      },
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]"
-      }
-    },
-    {
-      "apiVersion": "2019-03-01",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(variables('vmName'), copyIndex())]",
-      "location": "[variables('location')]",
-      "copy": {
-        "name": "vmcopy",
-        "count": "[parameters('count')]"
-      },
-      "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
-        "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
-        },
-        "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
-          "adminUsername": "[variables('adminUsername')]",
-          "adminPassword": "[variables('adminPassword')]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "publisher": "[variables('imagePublisher')]",
-            "offer": "[variables('imageOffer')]",
-            "sku": "[variables('imageSku')]",
-            "version": "[variables('imageVersion')]"
-          },
-          "osDisk": {
-            "createOption": "FromImage",
-            "managedDisk": {
-              "storageAccountType": "[variables('storageAccountType')]"
-            }
-          }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
-            }
-          ]
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json",
+    "contentVersion": "2.0.0.0",
+    "parameters": {
+        "storageAccountKey": {
+            "type": "securestring"
         }
-      },
-      "resources": [
+    },
+    "variables": {
+        "virtualNetworkName": "",
+        "virtualNetworkResourceGroupName": "",
+        "subnetName": "",
+        "nsgName": "",
+        "storageAccountName": "[concat('jnk',uniqueString(resourceGroup().id))]",
+        "vnetID": "[resourceId(variables('virtualNetworkResourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+        "publicIPAddressType": "Dynamic",
+        "storageAccountContainerName": "vhds",
+        "storageAccountType": "Standard_LRS",
+        "startupScriptURI": "",
+        "startupScriptName": "",
+        "jenkinsServerURL": "",
+        "clientSecrets": [],
+        "jenkinsTag": "ManagedByAzureVMAgents",
+        "resourceTag": "AzureJenkins",
+        "cloudTag": "",
+        "blobEndpointSuffix": ".blob.core.windows.net/"
+    },
+    "resources": [
         {
-          "type": "extensions",
-          "name": "[concat('customScript', variables('vmName'), copyIndex())]",
-          "apiVersion": "2019-03-01",
-          "location": "[variables('location')]",
-          "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
-          ],
-          "properties": {
-            "publisher": "Microsoft.Compute",
-            "type": "CustomScriptExtension",
-            "typeHandlerVersion": "1.7",
-            "autoUpgradeMinorVersion": true,
-            "settings": {
-              "fileUris": [
-                "[variables('startupScriptURI')]"
-              ],
-              "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+            "apiVersion": "2016-01-01",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountName')]",
+            "location": "[variables('location')]",
+            "sku": {
+                "name": "[variables('storageAccountType')]"
             },
-            "protectedSettings": {
-              "storageAccountName": "[variables('storageAccountName')]",
-              "storageAccountKey": "[parameters('storageAccountKey')]"
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
             }
-          }
+        },
+        {
+            "apiVersion": "2019-04-01",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            },
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]"
+            }
+        },
+        {
+            "apiVersion": "2019-03-01",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[concat(variables('vmName'), copyIndex())]",
+            "location": "[variables('location')]",
+            "copy": {
+                "name": "vmcopy",
+                "count": "[parameters('count')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat(variables('vmName'), copyIndex())]",
+                    "adminUsername": "[variables('adminUsername')]",
+                    "adminPassword": "[variables('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('imagePublisher')]",
+                        "offer": "[variables('imageOffer')]",
+                        "sku": "[variables('imageSku')]",
+                        "version": "[variables('imageVersion')]"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage",
+                        "managedDisk": {
+                            "storageAccountType": "[variables('storageAccountType')]"
+                        }
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                        }
+                    ]
+                }
+            },
+            "resources": [
+                {
+                    "type": "extensions",
+                    "name": "[concat('customScript', variables('vmName'), copyIndex())]",
+                    "apiVersion": "2019-03-01",
+                    "location": "[variables('location')]",
+                    "dependsOn": [
+                        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
+                    ],
+                    "properties": {
+                        "publisher": "Microsoft.Compute",
+                        "type": "CustomScriptExtension",
+                        "typeHandlerVersion": "1.7",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                            "fileUris": [
+                                "[variables('startupScriptURI')]"
+                            ],
+                            "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+                        },
+                        "protectedSettings": {
+                            "storageAccountName": "[variables('storageAccountName')]",
+                            "storageAccountKey": "[parameters('storageAccountKey')]"
+                      }
+                    }
+                }
+            ],
+            "tags": {
+                "JenkinsManagedTag": "[variables('jenkinsTag')]",
+                "JenkinsResourceTag": "[variables('resourceTag')]",
+                "JenkinsCloudTag": "[variables('cloudTag')]"
+            }
         }
-      ],
-      "tags": {
-        "JenkinsManagedTag": "[variables('jenkinsTag')]",
-        "JenkinsResourceTag": "[variables('resourceTag')]",
-        "JenkinsCloudTag": "[variables('cloudTag')]"
-      }
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
This PR adjusts the template json files to make them better diffable.

- adjust indentation to four spaces
- adjust `resourceTag` name `AzureJenkinsMasterId` -> `AzureJenkins`
- adjust `computername` -> `computerName`
- adjust schema `2015-01-01` -> `2019-04-01`
- adjust `imageID` -> `imageId`
- reorder `apiVersion` tag

To see the diff on GitHub I recommend to hide whitespace changes (eg. append `&w=1` to URL).

This helps me and hopefully others to read the code and json to easier contribute back changes. I use the Atom Split Diff package that helps comparing the different json files to understand the changes for all the variants.