### PR TITLE
Use GitHub as a source of plugin documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <name>Azure VM Agents</name>
     <description>Provisions agents on Azure cloud</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Azure+VM+Agents+Plugin</url>
+    <url>https://github.com/jenkinsci/azure-vm-agents-plugin</url>
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>


### PR DESCRIPTION
From what I see https://wiki.jenkins-ci.org/display/JENKINS/Azure+VM+Agents+Plugin is just a clone of the README.md contents. I suggest just switching to GitHub as a main source of the plugin docs so that Wiki content can be depreecated.

See https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/ for more info about the documentation migration