### PR TITLE
Termination Script Support

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -587,7 +587,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
             }
 
             Thread loggingThread = new Thread(new Runnable() {
-                private final int flushInterval = 30000;
+                private final static int flushInterval = 30000;
                 public void run() {
                     try {
                         while (terminateResults != null) {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -567,7 +567,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
                 }
             };
 
-            PrintStream terminateStream = new PrintStream(terminateResults);
+            PrintStream terminateStream = new PrintStream(terminateResults, true, "UTF-8");
 
             final boolean isUnix = this.getOsType().equals(OperatingSystemTypes.LINUX);
             // Check if VM is already stopped or stopping or getting deleted ,

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -556,7 +556,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
             PrintStream terminateStream = new LogTaskListener(LOGGER, Level.INFO).getLogger();
 
             final boolean isUnix = this.getOsType().equals(OperatingSystemTypes.LINUX);
-            boolean skipTerminateScript = StringUtils.isNotBlank(terminateScript);
+            boolean skipTerminateScript = StringUtils.isBlank(terminateScript);
             // Check if VM is already stopped or stopping or getting deleted ,
             // if yes then there is no point in trying to connect
             // Added this check - since after restarting jenkins master,

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -587,12 +587,12 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
             }
 
             Thread loggingThread = new Thread(new Runnable() {
-                private final static int flushInterval = 30000;
+                private static final int FLUSH_INTERVAL = 30000;
                 public void run() {
                     try {
                         while (terminateResults != null) {
                             terminateResults.flush();
-                            Thread.sleep(flushInterval);
+                            Thread.sleep(FLUSH_INTERVAL);
                         }
                     } catch (IOException e) {
                         // ignoring exception purposefully

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -287,6 +287,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
     private final String initScript;
 
+    private final String terminateScript;
+
     private final String credentialsId;
 
     private final String agentWorkspace;
@@ -379,6 +381,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
             String agentLaunchMethod,
             boolean preInstallSsh,
             String initScript,
+            String terminateScript,
             String credentialsId,
             String virtualNetworkName,
             String virtualNetworkResourceGroupName,
@@ -428,6 +431,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         this.osType = osType;
         this.shutdownOnIdle = shutdownOnIdle;
         this.initScript = initScript;
+        this.terminateScript = terminateScript;
         this.agentLaunchMethod = agentLaunchMethod;
         this.preInstallSsh = preInstallSsh;
         this.credentialsId = credentialsId;
@@ -594,6 +598,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
                 isBasic ? defaultProperties.get(Constants.DEFAULT_LAUNCH_METHOD) : template.getAgentLaunchMethod());
         templateProperties.put("initScript",
                 isBasic ? getBasicInitScript(template) : template.getInitScript());
+        templateProperties.put("terminateScript",
+                isBasic ? "" : template.getTerminateScript());
         templateProperties.put("virtualNetworkName",
                 isBasic ? "" : template.getVirtualNetworkName());
         templateProperties.put("virtualNetworkResourceGroupName",
@@ -923,6 +929,10 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
     public String getInitScript() {
         return initScript;
+    }
+
+    public String getTerminateScript() {
+        return terminateScript;
     }
 
     public String getCredentialsId() {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.util.RawValue;
+
 import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.*;
@@ -142,7 +142,6 @@ public final class AzureVMManagementServiceDelegate {
     private static final String INSTALL_MAVEN_UBUNTU_FILENAME = "/scripts/ubuntuInstallMavenScript.sh";
 
     private static final String INSTALL_DOCKER_UBUNTU_FILENAME = "/scripts/ubuntuInstallDockerScript.sh";
-
 
     private static final String PRE_INSTALL_SSH_FILENAME = "/scripts/sshInit.ps1";
 
@@ -1028,6 +1027,7 @@ public final class AzureVMManagementServiceDelegate {
                     deploymentName,
                     template.getRetentionStrategy(),
                     (String) properties.get("initScript"),
+                    (String) properties.get("terminateScript"),
                     azureCloud.getAzureCredentialsId(),
                     (String) properties.get("agentLaunchMethod"),
                     CleanUpAction.DEFAULT,

--- a/src/main/java/com/microsoft/azure/vmagent/builders/AdvancedImage.java
+++ b/src/main/java/com/microsoft/azure/vmagent/builders/AdvancedImage.java
@@ -35,6 +35,8 @@ public class AdvancedImage {
 
     private String initScript;
 
+    private String terminateScript;
+
     private boolean executeInitScriptAsRoot;
 
     private boolean doNotUseMachineIfInitFails;
@@ -77,6 +79,7 @@ public class AdvancedImage {
                          String agentLaunchMethod,
                          boolean preInstallSsh,
                          String initScript,
+                         String terminateScript,
                          boolean executeInitScriptAsRoot,
                          boolean doNotUseMachineIfInitFails,
                          boolean enableMSI,
@@ -106,6 +109,7 @@ public class AdvancedImage {
         this.agentLaunchMethod = agentLaunchMethod;
         this.preInstallSsh = preInstallSsh;
         this.initScript = initScript;
+        this.terminateScript = terminateScript;
         this.executeInitScriptAsRoot = executeInitScriptAsRoot;
         this.doNotUseMachineIfInitFails = doNotUseMachineIfInitFails;
         this.enableMSI = enableMSI;
@@ -136,6 +140,7 @@ public class AdvancedImage {
     public String getImageId() {
         return imageId;
     }
+
     public String getImagePublisher() {
         return imagePublisher;
     }
@@ -184,6 +189,10 @@ public class AdvancedImage {
         return initScript;
     }
 
+    public String getTerminateScript() {
+        return terminateScript;
+    }
+
     public boolean isExecuteInitScriptAsRoot() {
         return executeInitScriptAsRoot;
     }
@@ -191,7 +200,6 @@ public class AdvancedImage {
     public boolean isDoNotUseMachineIfInitFails() {
         return doNotUseMachineIfInitFails;
     }
-
 
     public boolean isEnableMSI() {
         return enableMSI;

--- a/src/main/java/com/microsoft/azure/vmagent/builders/AdvancedImageBuilder.java
+++ b/src/main/java/com/microsoft/azure/vmagent/builders/AdvancedImageBuilder.java
@@ -28,6 +28,7 @@ public class AdvancedImageBuilder extends AdvancedImageFluent<AdvancedImageBuild
         fluent.withLaunchMethod(image.getAgentLaunchMethod());
         fluent.withPreInstallSsh(image.isPreInstallSsh());
         fluent.withInitScript(image.getInitScript());
+        fluent.withTerminateScript(image.getTerminateScript());
         fluent.withVirtualNetworkName(image.getVirtualNetworkName());
         fluent.withVirtualNetworkResourceGroupName(image.getVirtualNetworkResourceGroupName());
         fluent.withSubnetName(image.getSubnetName());
@@ -61,6 +62,7 @@ public class AdvancedImageBuilder extends AdvancedImageFluent<AdvancedImageBuild
         fluent.withLaunchMethod(image.getAgentLaunchMethod());
         fluent.withPreInstallSsh(image.isPreInstallSsh());
         fluent.withInitScript(image.getInitScript());
+        fluent.withTerminateScript(image.getTerminateScript());
         fluent.withVirtualNetworkName(image.getVirtualNetworkName());
         fluent.withVirtualNetworkResourceGroupName(image.getVirtualNetworkResourceGroupName());
         fluent.withSubnetName(image.getSubnetName());
@@ -89,6 +91,7 @@ public class AdvancedImageBuilder extends AdvancedImageFluent<AdvancedImageBuild
                 fluent.getAgentLaunchMethod(),
                 fluent.isPreInstallSsh(),
                 fluent.getInitScript(),
+                fluent.getTerminateScript(),
                 fluent.isExecuteInitScriptAsRoot(),
                 fluent.isDoNotUseMachineIfInitFails(),
                 fluent.isEnableMSI(),

--- a/src/main/java/com/microsoft/azure/vmagent/builders/AdvancedImageFluent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/builders/AdvancedImageFluent.java
@@ -38,6 +38,8 @@ public class AdvancedImageFluent<T extends AdvancedImageFluent<T>> {
 
     private String initScript;
 
+    private String terminateScript;
+
     private boolean executeInitScriptAsRoot;
 
     private boolean doNotUseMachineIfInitFails;
@@ -136,6 +138,11 @@ public class AdvancedImageFluent<T extends AdvancedImageFluent<T>> {
 
     public T withInitScript(String initScript) {
         this.initScript = initScript;
+        return (T) this;
+    }
+
+    public T withTerminateScript(String terminateScript) {
+        this.terminateScript = terminateScript;
         return (T) this;
     }
 
@@ -266,6 +273,10 @@ public class AdvancedImageFluent<T extends AdvancedImageFluent<T>> {
 
     public String getInitScript() {
         return initScript;
+    }
+
+    public String getTerminateScript() {
+        return terminateScript;
     }
 
     public boolean isExecuteInitScriptAsRoot() {

--- a/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateBuilder.java
+++ b/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateBuilder.java
@@ -111,6 +111,7 @@ public class AzureVMTemplateBuilder extends AzureVMTemplateFluent<AzureVMTemplat
                 fluent.getAdvancedImage().getAgentLaunchMethod(),
                 fluent.getAdvancedImage().isPreInstallSsh(),
                 fluent.getAdvancedImage().getInitScript(),
+                fluent.getAdvancedImage().getTerminateScript(),
                 fluent.getCredentialsId(),
                 fluent.getAdvancedImage().getVirtualNetworkName(),
                 fluent.getAdvancedImage().getVirtualNetworkResourceGroupName(),

--- a/src/main/java/com/microsoft/azure/vmagent/remote/AzureVMAgentSSHLauncher.java
+++ b/src/main/java/com/microsoft/azure/vmagent/remote/AzureVMAgentSSHLauncher.java
@@ -317,6 +317,10 @@ public class AzureVMAgentSSHLauncher extends ComputerLauncher {
             throw e;
         }
     }
+    
+    public void copyFileToRemote(AzureVMAgent agent, InputStream stream, String remotePath) throws Exception {
+    	copyFileToRemote(connectToSsh(agent), stream, remotePath);
+    }
 
     private void copyFileToRemote(Session jschSession, InputStream stream, String remotePath) throws Exception {
         LOGGER.log(Level.INFO,
@@ -356,6 +360,14 @@ public class AzureVMAgentSSHLauncher extends ComputerLauncher {
         }
     }
 
+    public int executeRemoteCommand(AzureVMAgent agent, String command, PrintStream logger, boolean isUnix)  throws Exception {
+    	return executeRemoteCommand(connectToSsh(agent), command, logger, isUnix, false, null);
+    }
+    
+    public int executeRemoteCommand(AzureVMAgent agent, String command, PrintStream logger, boolean isUnix, boolean executeAsRoot, String passwordIfRoot)  throws Exception {
+    	return executeRemoteCommand(connectToSsh(agent), command, logger, isUnix, executeAsRoot, passwordIfRoot);
+    }
+    
     /* Helper method for most common call (without root). */
     private int executeRemoteCommand(Session jschSession, String command, PrintStream logger, boolean isUnix) {
         return executeRemoteCommand(jschSession, command, logger, isUnix, false, null);

--- a/src/main/java/com/microsoft/azure/vmagent/util/TemplateUtil.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/TemplateUtil.java
@@ -41,6 +41,7 @@ public final class TemplateUtil {
                 && StringUtils.equals(a.getAgentLaunchMethod(), b.getAgentLaunchMethod())
                 && a.getPreInstallSsh() == b.getPreInstallSsh()
                 && StringUtils.equals(a.getInitScript(), b.getInitScript())
+                && StringUtils.equals(a.getTerminateScript(), b.getTerminateScript())
                 && a.getExecuteInitScriptAsRoot() == b.getExecuteInitScriptAsRoot()
                 && a.isEnableMSI() == b.isEnableMSI()
                 && a.isEnableUAMI() == b.isEnableUAMI()

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
@@ -186,6 +186,10 @@
                              help="/plugin/azure-vm-agents/help-doNotUseMachineIfInitFails.html">
                         <f:checkbox default="true"/>
                     </f:entry>
+                    
+                    <f:entry title="${%Terminate_Script}" field="terminateScript" help="/plugin/azure-vm-agents/help-terminateScript.html">
+                        <f:textarea/>
+                    </f:entry>
 
                     <f:entry title="${%Enable_MSI}" field="enableMSI"
                         help="/plugin/azure-vm-agents/help-enableMSI.html">

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
@@ -47,6 +47,7 @@ Pre_Install_Ssh=Pre-Install SSH in Windows Slave (Check when using Windows and S
 
 Initialization_Configuration=VM First Startup Configuration
 Init_Script=Initialization Script
+Terminate_Script=Termination Script
 Execute_Init_Script_As_Root=Run Initialization Script As Root (Linux Only)
 Do_Not_Use_Machine_If_Init_Fails=Don't Use VM If Initialization Script Fails
 

--- a/src/main/webapp/help-terminateScript.html
+++ b/src/main/webapp/help-terminateScript.html
@@ -1,0 +1,8 @@
+<div>
+	<p>
+		<b>This is to support termination activities for anything that should be done in the event that this
+			template is marked for tear down.  This is not strictly required, but assists in cleanup if this node needs to make
+		    changes outside of the created Azure node.</b>
+	</p>
+	<p>Termination scripts work the same here as initialization scripts, but are executed just before node teardown.</p>
+</div>

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMCloud.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMCloud.java
@@ -78,6 +78,7 @@ public class ITAzureVMCloud extends IntegrationTest {
             final boolean isShutdownOnIdle = false;
             final int retentionTimeInMin = 30;
             final String initScript = "";
+            final String terminateScript = "";
             final String agentLaunchMethod = Constants.LAUNCH_METHOD_SSH;
             final boolean executeInitScriptAsRoot = true;
             final boolean doNotUseMachineIfInitFails = true;
@@ -101,6 +102,7 @@ public class ITAzureVMCloud extends IntegrationTest {
             when(templateMock.isShutdownOnIdle()).thenReturn(isShutdownOnIdle);
             when(templateMock.getRetentionTimeInMin()).thenReturn(retentionTimeInMin);
             when(templateMock.getInitScript()).thenReturn(initScript);
+            when(templateMock.getTerminateScript()).thenReturn(terminateScript);
             when(templateMock.getAgentLaunchMethod()).thenReturn(agentLaunchMethod);
             when(templateMock.getResourceGroupName()).thenReturn(testEnv.azureResourceGroup);
             when(templateMock.getExecuteInitScriptAsRoot()).thenReturn(executeInitScriptAsRoot);
@@ -121,6 +123,7 @@ public class ITAzureVMCloud extends IntegrationTest {
             Assert.assertEquals(jvmOptions, newAgent.getJvmOptions());
             Assert.assertEquals(retentionTimeInMin, newAgent.getRetentionTimeInMin());
             Assert.assertEquals(initScript, newAgent.getInitScript());
+            Assert.assertEquals(terminateScript, newAgent.getTerminateScript());
             Assert.assertEquals(agentLaunchMethod, newAgent.getAgentLaunchMethod());
             Assert.assertEquals(executeInitScriptAsRoot, newAgent.getExecuteInitScriptAsRoot());
             Assert.assertEquals(doNotUseMachineIfInitFails, newAgent.getDoNotUseMachineIfInitFails());

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMManagementServiceDelegate.java
@@ -89,6 +89,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
         when(templateMock.getResourceGroupName()).thenReturn(testEnv.azureResourceGroup);
         when(templateMock.getLocation()).thenReturn(testEnv.azureLocation);
         when(templateMock.getInitScript()).thenReturn(writtenData);
+        when(templateMock.getTerminateScript()).thenReturn(writtenData);
         when(templateMock.getStorageAccountType()).thenReturn(SkuName.STANDARD_LRS.toString());
         when(templateMock.getResourceGroupReferenceType()).thenReturn(testEnv.azureResourceGroupReferenceType);
         AzureVMCloud cloudMock = mock(AzureVMCloud.class);

--- a/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
@@ -336,6 +336,7 @@ public class IntegrationTest {
         final String templateName = "t" + TestEnvironment.GenerateRandomString(7);
         final String osType = OS_TYPE;
         final String initScript = "echo \"" + UUID.randomUUID().toString() + "\"";
+        final String terminateScript = "echo \"" + UUID.randomUUID().toString() + "\"";
         final String launchMethod = Constants.LAUNCH_METHOD_SSH;
         final String vmUser = "tstVmUser";
         final Secret vmPassword = Secret.fromString(TestEnvironment.GenerateRandomString(16) + "AA@@12345@#$%^&*-_!+=[]{}|\\:`,.?/~\\\"();\'");
@@ -361,6 +362,7 @@ public class IntegrationTest {
         when(templateMock.getTemplateName()).thenReturn(templateName);
         when(templateMock.getOsType()).thenReturn(osType);
         when(templateMock.getInitScript()).thenReturn(initScript);
+        when(templateMock.getTerminateScript()).thenReturn(terminateScript);
         when(templateMock.getAgentLaunchMethod()).thenReturn(launchMethod);
         when(templateMock.getImageTopLevelType()).thenReturn(Constants.IMAGE_TOP_LEVEL_ADVANCED);
         when(templateMock.isTopLevelType(Constants.IMAGE_TOP_LEVEL_BASIC)).thenReturn(false);

--- a/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/advanced.yaml
+++ b/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/advanced.yaml
@@ -31,6 +31,7 @@ jenkins:
               gallerySubscriptionId: "e5587777-5750-4d2e-9e45-d6fbae67b8ea"
             imageTopLevelType: "advanced"
             initScript: "yum install -y java\nyum install -y nodejs\ncat /etc/hosts"
+            terminateScript: ""
             installDocker: false
             installGit: false
             installMaven: false


### PR DESCRIPTION
Added support for Termination Script to Azure VM Agent.  When the agent begins deprovisioning a node the Termination Script can be set so that it executes right before as a means to make changes or save data from a node before it is removed.

Some chunks of code were pulled from the initialization code and modified to more specifically fit the termination script purposes.