### PR TITLE
Fix agents getting deleted on reboot when using JCasC

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -128,7 +128,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         }
 
         private ImageReferenceTypeClass() {
-            // used for readResolve to maintain compatibility
+            this.type = determineType();
         }
 
         private ImageReferenceType determineType() {
@@ -403,6 +403,9 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         this.labels = labels;
         this.location = location;
         this.availabilityType = availabilityType;
+        if (availabilityType == null) {
+            this.availabilityType = new AvailabilityTypeClass();
+        }
         this.virtualMachineSize = virtualMachineSize;
         this.storageAccountType = storageAccountType;
         this.storageAccountName = getStorageAccountName(
@@ -428,6 +431,9 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         this.installGit = installGit;
         this.installMaven = installMaven;
         this.imageReference = imageReference;
+        if (imageReference == null) {
+            this.imageReference = new ImageReferenceTypeClass();
+        }
         this.osType = osType;
         this.shutdownOnIdle = shutdownOnIdle;
         this.initScript = initScript;


### PR DESCRIPTION
[TemplateUtil#checkSame](https://github.com/jenkinsci/azure-vm-agents-plugin/blob/dev/src/main/java/com/microsoft/azure/vmagent/util/TemplateUtil.java#L10) returns false on startup due to availabilityType and
imageReference being null, this causes the retention strategy to think
the template has changed.

This is caused by jcasc not invoking the #readResolve method, the
workaround is to do the compatibility work in the constructor instead

We're only noticing this bug because of the corona virus causing huge VM shortages in the UK, we're struggling to provision VMs at all, and if we lose them due to a reboot it can cause a huge problem for us.

Testing:

Install the `configuration-as-code` plugin

Create a service principal credential (for creating the VM) and username password (for ssh authentication) credential.

Create a jenkins.yaml file in the JENKINS_HOME, if running from `hpi:run` then put it in the work directory,

The configuration that I used for testing was:

<details>

<summary>JCasC yaml</summary>

```yaml
jenkins:
  clouds:
    - azureVM:
        azureCredentialsId: "jenkinsServicePrincipal"
        cloudName: "tim"
        configurationStatus: "pass"
        deploymentTimeout: 1200
        maxVirtualMachinesLimit: 10
        newResourceGroupName: "timj-vm-agents-debug"
        resourceGroupReferenceType: "new"
        vmTemplates:
          - agentLaunchMethod: "SSH"
            agentWorkspace: "/tmp/jenkins"
            builtInImage: "Ubuntu 16.04 LTS"
            credentialsId: "jenkins-ssh"
            diskType: "managed"
            doNotUseMachineIfInitFails: true
            enableMSI: false
            enableUAMI: false
            ephemeralOSDisk: false
            executeInitScriptAsRoot: true
            imageTopLevelType: "basic"
            installDocker: false
            installGit: false
            installMaven: false
            location: "Central US"
            newStorageAccountName: "timjdebugazurevm"
            noOfParallelJobs: 1
            osDiskSize: 0
            osType: "Linux"
            preInstallSsh: true
            retentionStrategy:
              azureVMCloudPool:
                poolSize: 3
                retentionInHours: 24
            shutdownOnIdle: false
            storageAccountNameReferenceType: "new"
            storageAccountType: "Standard_LRS"
            templateDesc: "Tim description"
            templateDisabled: false
            templateName: "tim"
            virtualMachineSize: "Standard_D4_v3"
            usageMode: "Use this node as much as possible"
```

</details>

adjust the storage account name and others as needed.

Create a job, I just used a freestyle job with a shell step having `echo 'hi'` in it.

Run the job wait for an agent to be provisioned, and see the job pass

Reboot jenkins, 

The agent should not be deleted during startup,
Run the job again
The job should start instantly as there will already be an agent provisioned.

