### PR TITLE
Avoid deadlock (Fix for JENKINS-54776)

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -1024,7 +1024,9 @@ public class AzureVMCloud extends Cloud {
     private void releaseLockForAgent(AzureVMAgent agent) {
         synchronized (agentLocks) {
             AtomicInteger lockCount = agentLocks.get(agent);
-            if (lockCount != null) {
+            if (lockCount != null && lockCount.decrementAndGet() == 0) {
+                agentLocks.remove(agent);
+            }
                 int currentLockCount = lockCount.decrementAndGet();
                 if (currentLockCount == 0) {
                     agentLocks.remove(agent);

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -75,7 +75,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -1027,11 +1027,6 @@ public class AzureVMCloud extends Cloud {
             if (lockCount != null && lockCount.decrementAndGet() == 0) {
                 agentLocks.remove(agent);
             }
-                int currentLockCount = lockCount.decrementAndGet();
-                if (currentLockCount == 0) {
-                    agentLocks.remove(agent);
-                }
-            }
         }
     }
 


### PR DESCRIPTION
Hello,

this fixes the issue JENKINS-54776.

The main problem for the issue was a deadlock, becaus the azure-vm-agent plugin was holding the lock of the node object while another plugin (branch-api-plugin) also tried to get lock of the node.

I moved the locks to an private map so that no other plugin can interfere with the locking logic.

This versions is running on our production server for a few days without problems.