### PR TITLE
Fix NullPointerException after restart of Jenkins controller when agent resumes from suspend

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -132,7 +132,7 @@ public class AzureVMCloud extends Cloud {
     private List<AzureTagPair> cloudTags;
 
     //The map should not be accessed without acquiring a lock of the map
-    private Map<AzureVMAgent, AtomicInteger> agentLocks = new HashMap<>();
+    private transient Map<AzureVMAgent, AtomicInteger> agentLocks = new HashMap<>();
 
     private Supplier<Azure> createAzureClientSupplier() {
         return Suppliers.memoize(() -> AzureClientUtil.getClient(credentialsId))::get;

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -132,7 +132,7 @@ public class AzureVMCloud extends Cloud {
     private List<AzureTagPair> cloudTags;
 
     //The map should not be accessed without acquiring a lock of the map
-    private final transient Map<AzureVMAgent, AtomicInteger> agentLocks = new HashMap<>();
+    private Map<AzureVMAgent, AtomicInteger> agentLocks = new HashMap<>();
 
     private Supplier<Azure> createAzureClientSupplier() {
         return Suppliers.memoize(() -> AzureClientUtil.getClient(credentialsId))::get;
@@ -200,6 +200,10 @@ public class AzureVMCloud extends Cloud {
             if (instTemplates != null && vmTemplates == null) {
                 vmTemplates = instTemplates;
                 instTemplates = null;
+            }
+
+            if (agentLocks == null) {
+                agentLocks = new HashMap<>();
             }
 
             // Walk the list of templates and assign the parent cloud (which is transient).


### PR DESCRIPTION
Hi,

after an upgrade of our Jenkins Master, we started to get NullPointerException when an agent should wake up after it was suspended.

It seems that I did not correctly understand the Jenkins Serialization/Deseralization logic and had an error in my last pull request.
After Deserialization the `agentLocks` field was null and that created the NullPointerException.

The main problem was that the field was transient. I removed the transient attribute and made sure in the `readResolve` method that a null field will be initialized with a `HashMap`.


 