### PR TITLE
Change storage account urls to https

### DIFF
--- a/src/main/resources/customImageTemplate.json
+++ b/src/main/resources/customImageTemplate.json
@@ -78,7 +78,7 @@
                         },
                         "createOption": "FromImage",
                         "vhd": {
-                            "uri": "[concat('http://',variables('storageAccountName'),variables('blobEndpointSuffix'),variables('storageAccountContainerName'),'/', variables('vmName'), copyIndex(), 'OSDisk.vhd')]"
+                            "uri": "[concat('https://',variables('storageAccountName'),variables('blobEndpointSuffix'),variables('storageAccountContainerName'),'/', variables('vmName'), copyIndex(), 'OSDisk.vhd')]"
                         }
                     }
                 },

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -86,7 +86,7 @@
                         },
                         "createOption": "FromImage",
                         "vhd": {
-                            "uri": "[concat('http://',variables('storageAccountName'),variables('blobEndpointSuffix'),variables('storageAccountContainerName'),'/', variables('vmName'), copyIndex(), 'OSDisk.vhd')]"
+                            "uri": "[concat('https://',variables('storageAccountName'),variables('blobEndpointSuffix'),variables('storageAccountContainerName'),'/', variables('vmName'), copyIndex(), 'OSDisk.vhd')]"
                         }
                     }
                 },

--- a/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
@@ -30,6 +30,9 @@
             "tags": {
                 "JenkinsManagedTag": "[variables('jenkinsTag')]",
                 "JenkinsResourceTag": "[variables('resourceTag')]"
+            },
+            "properties": {
+                "supportsHttpsTrafficOnly": true
             }
         },
         {

--- a/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
@@ -38,6 +38,9 @@
             "tags": {
                 "JenkinsManagedTag": "[variables('jenkinsTag')]",
                 "JenkinsResourceTag": "[variables('resourceTag')]"
+            },
+            "properties": {
+                "supportsHttpsTrafficOnly": true
             }
         },
         {

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -30,6 +30,9 @@
             "tags": {
                 "JenkinsManagedTag": "[variables('jenkinsTag')]",
                 "JenkinsResourceTag": "[variables('resourceTag')]"
+            },
+            "properties": {
+                "supportsHttpsTrafficOnly": true
             }
         },
         {
@@ -92,7 +95,7 @@
                     "osDisk": {
                         "name": "osdisk",
                         "vhd": {
-                            "uri": "[concat('http://',variables('storageAccountName'),variables('blobEndpointSuffix'),variables('storageAccountContainerName'),'/', variables('vmName'), copyIndex(), 'OSDisk.vhd')]"
+                            "uri": "[concat('https://',variables('storageAccountName'),variables('blobEndpointSuffix'),variables('storageAccountContainerName'),'/', variables('vmName'), copyIndex(), 'OSDisk.vhd')]"
                         },
                         "caching": "[if(bool(variables('ephemeralOSDisk')), 'ReadOnly', json('null'))]",
                         "diffDiskSettings": "[if(bool(variables('ephemeralOSDisk')), json('{\"option\": \"Local\"}'), json('null'))]",

--- a/src/main/resources/referenceImageTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithManagedDisk.json
@@ -30,6 +30,9 @@
             "tags": {
                 "JenkinsManagedTag": "[variables('jenkinsTag')]",
                 "JenkinsResourceTag": "[variables('resourceTag')]"
+            },
+            "properties": {
+                "supportsHttpsTrafficOnly": true
             }
         },
         {

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -38,6 +38,9 @@
             "tags": {
                 "JenkinsManagedTag": "[variables('jenkinsTag')]",
                 "JenkinsResourceTag": "[variables('resourceTag')]"
+            },
+            "properties": {
+                "supportsHttpsTrafficOnly": true
             }
         },
         {
@@ -100,7 +103,7 @@
                     "osDisk": {
                         "name": "osdisk",
                         "vhd": {
-                            "uri": "[concat('http://',variables('storageAccountName'),variables('blobEndpointSuffix'),variables('storageAccountContainerName'),'/', variables('vmName'), copyIndex(), 'OSDisk.vhd')]"
+                            "uri": "[concat('https://',variables('storageAccountName'),variables('blobEndpointSuffix'),variables('storageAccountContainerName'),'/', variables('vmName'), copyIndex(), 'OSDisk.vhd')]"
                         },
                         "caching": "[if(bool(variables('ephemeralOSDisk')), 'ReadOnly', json('null'))]",
                         "diffDiskSettings": "[if(bool(variables('ephemeralOSDisk')), json('{\"option\": \"Local\"}'), json('null'))]",

--- a/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
@@ -38,6 +38,9 @@
             "tags": {
                 "JenkinsManagedTag": "[variables('jenkinsTag')]",
                 "JenkinsResourceTag": "[variables('resourceTag')]"
+            },
+            "properties": {
+                "supportsHttpsTrafficOnly": true
             }
         },
         {


### PR DESCRIPTION
This is a workaround for [JENKINS-61018](https://issues.jenkins-ci.org/browse/JENKINS-61018). But I am not sure if this could just be pulled in as is. Would break the users that don't require secure transfer or would this change work for both?