### PR TITLE
fix: avoid NPE for transient agentLocks

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -132,7 +132,7 @@ public class AzureVMCloud extends Cloud {
     private List<AzureTagPair> cloudTags;
 
     //The map should not be accessed without acquiring a lock of the map
-    private final transient Map<AzureVMAgent, AtomicInteger> agentLocks = new HashMap<>();
+    private transient Map<AzureVMAgent, AtomicInteger> agentLocks = new HashMap<>();
 
     private Supplier<Azure> createAzureClientSupplier() {
         return Suppliers.memoize(() -> AzureClientUtil.getClient(credentialsId))::get;
@@ -194,6 +194,7 @@ public class AzureVMCloud extends Cloud {
         resourceGroupName = getResourceGroupName(
                 resourceGroupReferenceType, newResourceGroupName, existingResourceGroupName);
         azureClient = createAzureClientSupplier();
+        agentLocks = new HashMap<>();
         configurationStatus = Constants.UNVERIFIED;
         synchronized (this) {
             // Ensure that renamed field is set


### PR DESCRIPTION
When using the Azure VM Agents Plugin version 1.5.1, we're encountering the following exception repeatedly:
```
Unexpected exception encountered while provisioning agent pos-smok726320
java.lang.NullPointerException
	at com.microsoft.azure.vmagent.AzureVMCloud.getLockForAgent(AzureVMCloud.java:1017)
	at com.microsoft.azure.vmagent.AzureVMCloud.lambda$provision$1(AzureVMCloud.java:682)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:71)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

The culprit appears to be a `final transient` field, which automatically becomes `null` as soon as it was deserialized once.
All other `transient` fields are non-`final` and are initialised in the `readResolve()` method, which I assume is what needs to happen here as well.

Unfortunately, I don't have time to introduce appropriate unit tests.