### PR TITLE
Make git download script more robust

### DIFF
--- a/src/main/resources/scripts/windowsInstallGitScript.ps1
+++ b/src/main/resources/scripts/windowsInstallGitScript.ps1
@@ -1,15 +1,15 @@
 # Install Git
-$source = "https://github.com/git-for-windows/git/releases/latest"
-$latestRelease = Invoke-WebRequest -UseBasicParsing $source -Headers @{"Accept"="application/json"}
-$json = $latestRelease.Content | ConvertFrom-Json
-$latestVersion = $json.tag_name
-$versionHead = $latestVersion.Substring(1, $latestVersion.IndexOf("windows")-2)
-$source = "https://github.com/git-for-windows/git/releases/download/v${versionHead}.windows.1/Git-${versionHead}-64-bit.exe"
-$destination = "C:\Git-${versionHead}-64-bit.exe"
-$webClient = New-Object System.Net.WebClient
-$webClient.DownloadFile($source, $destination)
+
+$git_url = "https://api.github.com/repos/git-for-windows/git/releases/latest"
+
+$asset = Invoke-RestMethod -Method Get -Uri $git_url | % assets | where name -like "*64-bit.exe"
+$destination = "C:\$($asset.name)"
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $destination
+
 $proc = Start-Process -FilePath $destination -ArgumentList "/VERYSILENT" -Wait -PassThru
 $proc.WaitForExit()
 $Env:Path += ";C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin"
 #Disable git credential manager, get more details in https://support.cloudbees.com/hc/en-us/articles/221046888-Build-Hang-or-Fail-with-Git-for-Windows
 git config --system --unset credential.helper
+
+git --version


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/pull/175

```
$ git --version
git version 2.31.1.windows.1
```