### PR TITLE
Use default subscription for managed identity if none specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To use this plugin to create VM agents, first you need to have an Azure Service 
 
 ### Add a New Azure VM Agents Cloud
 1. Within the Jenkins dashboard, click Manage Jenkins -> Configure System -> Scroll to the bottom of the page
-   and find the section with the dropdown "Add a new cloud" -> click on it and select "Microsoft Azure VM Agents"
+   and find the section with the dropdown "Add a new cloud" -> click on it and select "Azure VM Agents"
 2. Provide a name for the cloud (plugin will generate one for you if you leave it empty, but it's recommended to give it a meaningful name).
 3. Select an existing account from the Azure Credentials dropdown or add new "Microsoft Azure Service Principal" credentials in the Credentials Management page by filling out the Subscription ID, Client ID, Client Secret and the OAuth 2.0 Token Endpoint.
 4. Click on “Verify configuration” to make sure that the profile configuration is done correctly.

--- a/src/main/java/com/microsoft/azure/vmagent/util/AzureClientUtil.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/AzureClientUtil.java
@@ -22,6 +22,7 @@ import com.microsoft.azure.util.AzureBaseCredentials;
 import com.microsoft.azure.util.AzureCredentialUtil;
 import com.microsoft.azure.util.AzureCredentials;
 import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
+import hudson.Util;
 import io.jenkins.plugins.azuresdk.HttpClientRetriever;
 
 public final class AzureClientUtil {
@@ -50,10 +51,16 @@ public final class AzureClientUtil {
         AzureProfile profile = new AzureProfile(azureCredentials.getAzureEnvironment());
         TokenCredential tokenCredential = AzureCredentials.getTokenCredential(azureCredentials);
 
-        return AzureResourceManager
+        AzureResourceManager.Authenticated builder = AzureResourceManager
                 .configure()
                 .withHttpClient(HttpClientRetriever.get())
-                .authenticate(tokenCredential, profile)
+                .authenticate(tokenCredential, profile);
+
+        if (Util.fixEmpty(subscriptionId) == null) {
+            return builder.withDefaultSubscription();
+        }
+
+        return builder
                 .withSubscription(subscriptionId);
     }
 

--- a/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
@@ -59,7 +59,7 @@ public final class Constants {
 
     public static final String DEFAULT_GRAPH_ENDPOINT = "https://graph.windows.net/";
 
-    public static final String AZURE_CLOUD_DISPLAY_NAME = "Microsoft Azure VM Agents";
+    public static final String AZURE_CLOUD_DISPLAY_NAME = "Azure VM Agents";
 
     public static final String AZURE_VM_AGENT_CLOUD_DISPLAY_NAME = "Azure VM Agent";
 


### PR DESCRIPTION
Historically managed identity didn't have a subscription id on it, it does now but we should handle people not setting a default.

Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/278

_Note: there is a behaviour change from the previous SDK, before it would just pick the first subscription that was returned, now if more than one subscription is returned it will provide a list in the error message and tell you to pick one, it is recommended that you set the subscription on your managed identity credential_