### PR TITLE
Remove redundant storage acc from arm templates

### DIFF
--- a/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
@@ -20,19 +20,6 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-06-01",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('storageAccountName')]",
-            "location": "[variables('location')]",
-            "sku": {
-                "name": "[variables('storageAccountType')]"
-            },
-            "tags": {
-                "JenkinsManagedTag": "[variables('jenkinsTag')]",
-                "JenkinsResourceTag": "[variables('resourceTag')]"
-            }
-        },
-        {
             "apiVersion": "2019-04-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
@@ -70,7 +57,6 @@
                 "count": "[parameters('count')]"
             },
             "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
                 "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
             ],
             "properties": {

--- a/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
@@ -28,19 +28,6 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-06-01",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('storageAccountName')]",
-            "location": "[variables('location')]",
-            "sku": {
-                "name": "[variables('storageAccountType')]"
-            },
-            "tags": {
-                "JenkinsManagedTag": "[variables('jenkinsTag')]",
-                "JenkinsResourceTag": "[variables('resourceTag')]"
-            }
-        },
-        {
             "apiVersion": "2019-04-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
@@ -78,7 +65,6 @@
                 "count": "[parameters('count')]"
             },
             "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
                 "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
             ],
             "properties": {

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -20,19 +20,6 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-06-01",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('storageAccountName')]",
-            "location": "[variables('location')]",
-            "sku": {
-                "name": "[variables('storageAccountType')]"
-            },
-            "tags": {
-                "JenkinsManagedTag": "[variables('jenkinsTag')]",
-                "JenkinsResourceTag": "[variables('resourceTag')]"
-            }
-        },
-        {
             "apiVersion": "2019-04-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
@@ -70,7 +57,6 @@
                 "count": "[parameters('count')]"
             },
             "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
                 "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
             ],
             "properties": {

--- a/src/main/resources/referenceImageTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithManagedDisk.json
@@ -20,19 +20,6 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-06-01",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('storageAccountName')]",
-            "location": "[variables('location')]",
-            "sku": {
-                "name": "[variables('storageAccountType')]"
-            },
-            "tags": {
-                "JenkinsManagedTag": "[variables('jenkinsTag')]",
-                "JenkinsResourceTag": "[variables('resourceTag')]"
-            }
-        },
-        {
             "apiVersion": "2019-04-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
@@ -70,7 +57,6 @@
                 "count": "[parameters('count')]"
             },
             "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
                 "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
             ],
             "properties": {

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -28,19 +28,6 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-06-01",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('storageAccountName')]",
-            "location": "[variables('location')]",
-            "sku": {
-                "name": "[variables('storageAccountType')]"
-            },
-            "tags": {
-                "JenkinsManagedTag": "[variables('jenkinsTag')]",
-                "JenkinsResourceTag": "[variables('resourceTag')]"
-            }
-        },
-        {
             "apiVersion": "2019-04-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
@@ -78,7 +65,6 @@
                 "count": "[parameters('count')]"
             },
             "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
                 "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
             ],
             "properties": {

--- a/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
@@ -28,19 +28,6 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-06-01",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('storageAccountName')]",
-            "location": "[variables('location')]",
-            "sku": {
-                "name": "[variables('storageAccountType')]"
-            },
-            "tags": {
-                "JenkinsManagedTag": "[variables('jenkinsTag')]",
-                "JenkinsResourceTag": "[variables('resourceTag')]"
-            }
-        },
-        {
             "apiVersion": "2019-04-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
@@ -78,7 +65,6 @@
                 "count": "[parameters('count')]"
             },
             "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
                 "[concat('Microsoft.Network/networkInterfaces/', variables('vmName'), copyIndex(), 'NIC')]"
             ],
             "properties": {

--- a/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
@@ -27,7 +27,6 @@ import com.azure.resourcemanager.resources.models.ResourceGroups;
 import com.azure.resourcemanager.storage.models.SkuName;
 import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.resourcemanager.storage.models.StorageAccountKey;
-import com.azure.resourcemanager.storage.models.StorageAccountSkuType;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;


### PR DESCRIPTION
From what I can see the storage account is checked for existence via SDK and then created by SDK before any ARM deployments happen, so there doesn't appear to be a need for it to be in the ARM template

The storage account only appears to be used for unmanaged disk and for windows agents using inbound agent to connect.

Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/259