### PR TITLE
Add support for Accelerated Networking

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -310,6 +310,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
     private boolean spotInstance;
 
+    private boolean acceleratedNetworking;
+
     private final String nsgName;
 
     private final String jvmOptions;
@@ -591,6 +593,15 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
     @DataBoundSetter
     public void setSpotInstance(boolean spotInstance) {
         this.spotInstance = spotInstance;
+    }
+
+    public boolean isAcceleratedNetworking() {
+        return acceleratedNetworking;
+    }
+
+    @DataBoundSetter
+    public void setAcceleratedNetworking(boolean acceleratedNetworking) {
+        this.acceleratedNetworking = acceleratedNetworking;
     }
 
     public static Map<String, Object> getTemplateProperties(AzureVMAgentTemplate template) {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -565,6 +565,10 @@ public final class AzureVMManagementServiceDelegate {
                 addPublicIPResourceNode(tmp, cloud);
             }
 
+            if (template.isAcceleratedNetworking()) {
+              addAcceleratedNetworking(tmp);
+            }
+
             if (StringUtils.isNotBlank((String) properties.get("nsgName"))) {
                 addNSGNode(tmp, (String) properties.get("nsgName"));
             }
@@ -616,6 +620,17 @@ public final class AzureVMManagementServiceDelegate {
                 ObjectNode properties = (ObjectNode) resource.get("properties");
                 properties.put("priority", "Spot");
                 properties.put("evictionPolicy", "Delete");
+            }
+        }
+    }
+
+    private void addAcceleratedNetworking(JsonNode template) {
+        ArrayNode resources = (ArrayNode) template.get("resources");
+        for (JsonNode resource : resources) {
+            String type = resource.get("type").asText();
+            if (type.contains("networkInterfaces")) {
+                ObjectNode properties = (ObjectNode) resource.get("properties");
+                properties.put("enableAcceleratedNetworking", "true");
             }
         }
     }

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
@@ -104,6 +104,11 @@
                     <f:textbox/>
                 </f:entry>
             </f:optionalBlock>
+
+            <f:entry title="${%Enable_Accelerated_Networking}" field="acceleratedNetworking">
+                <f:checkbox/>
+            </f:entry>
+
         </f:section>
 
         <f:section title="${%Image_Configuration}">

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
@@ -73,3 +73,4 @@ Enable_MSI=Enable System Assigned Managed Identity(MSI)
 Enable_UAMI=Enable User Assigned Managed Identity(UAMI)
 UAMI_ID=Resource ID
 Maximum_Deployment_Size=Maximum Deployment Size (Optional)
+Enable_Accelerated_Networking=Enable Accelerated Networking (caution: not all VM sizes support this option)

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
@@ -73,4 +73,4 @@ Enable_MSI=Enable System Assigned Managed Identity(MSI)
 Enable_UAMI=Enable User Assigned Managed Identity(UAMI)
 UAMI_ID=Resource ID
 Maximum_Deployment_Size=Maximum Deployment Size (Optional)
-Enable_Accelerated_Networking=Enable Accelerated Networking (caution: not all VM sizes support this option)
+Enable_Accelerated_Networking=Enable Accelerated Networking

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/help-acceleratedNetworking.html
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/help-acceleratedNetworking.html
@@ -1,14 +1,12 @@
 Accelerated Networking enables single root I/O virtualization (SR-IOV) to a VM.
 This results in improved networking performance, lower latency and less CPU utilization.
-<br/>
-<br/>
-<b>Note:</b>
-<br/>
-Accelerated Networking is not available for all VM sizes; if you enable this option for an unsupported VM size, deployment will <em>fail</em>.<br/>
-Support for Accelerated Networking can be found in the individual virtual machine sizes documentation.
-<br/>
-<br/>
-<a href="https://docs.microsoft.com/en-us/azure/virtual-machines/sizes">Find virtual machine sizes that support Accelerated Networking</a>.
-<br/>
-<a href="https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli">Learn more about Accelerated Networking</a>.
+
+<p style="margin-bottom: 0"><strong>Note:</strong></p>
+
+<p style="margin-top: 0">Accelerated Networking is not available for all VM sizes; if you enable this option for an unsupported VM size, deployment will <em>fail</em>.<br/>
+    Support for Accelerated Networking can be found in the individual virtual machine sizes documentation.
+</p>
+
+<p style="margin-bottom: 0"><a href="https://docs.microsoft.com/en-us/azure/virtual-machines/sizes">Find virtual machine sizes that support Accelerated Networking</a>.</p>
+<p style="margin-top: 0"><a href="https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli">Learn more about Accelerated Networking</a>.</p>
 

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/help-acceleratedNetworking.html
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/help-acceleratedNetworking.html
@@ -1,0 +1,14 @@
+Accelerated Networking enables single root I/O virtualization (SR-IOV) to a VM.
+This results in improved networking performance, lower latency and less CPU utilization.
+<br/>
+<br/>
+<b>Note:</b>
+<br/>
+Accelerated Networking is not available for all VM sizes; if you enable this option for an unsupported VM size, deployment will <em>fail</em>.<br/>
+Support for Accelerated Networking can be found in the individual virtual machine sizes documentation.
+<br/>
+<br/>
+<a href="https://docs.microsoft.com/en-us/azure/virtual-machines/sizes">Find virtual machine sizes that support Accelerated Networking</a>.
+<br/>
+<a href="https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli">Learn more about Accelerated Networking</a>.
+


### PR DESCRIPTION
This adds the option to enable Accelerated Networking for a VM template.

Note that it is the user's responsibility to ensure the VM size is actually compatible with Accelerated Networking, as the list to check against is quite large and changeable.