### PR TITLE
Reduce locking, switching to copyonwrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ nb-configuration.xml
 nbactions.xml
 deployment.out
 .env
+logging.properties

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -482,7 +482,7 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
 
                 // Even if offline, a machine that has been temporarily marked offline
                 // should stay (this could be for investigation).
-                if (azureComputer.isSetOfflineByUser() && agentNode != null) {
+                if (azureComputer.isSetOfflineByUser()) {
                     LOGGER.log(getNormalLoggingLevel(),
                             "AzureVMAgentCleanUpTask: cleanVMs: node {0} was set offline by user, skipping",
                             agentNode.getDisplayName());
@@ -490,7 +490,7 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
                 }
 
                 // If the machine is in "keep" state, skip
-                if (agentNode != null && agentNode.isCleanUpBlocked()) {
+                if (agentNode.isCleanUpBlocked()) {
                     LOGGER.log(getNormalLoggingLevel(),
                             "AzureVMAgentCleanUpTask: cleanVMs: node {0} blocked to cleanup",
                             agentNode.getDisplayName());

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudVerificationTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudVerificationTask.java
@@ -212,7 +212,7 @@ public final class AzureVMCloudVerificationTask extends AsyncPeriodicWork {
 
     @Override
     public void execute(TaskListener arg0) {
-        for (Cloud cloud : Jenkins.getInstance().clouds) {
+        for (Cloud cloud : Jenkins.get().clouds) {
             if (cloud instanceof AzureVMCloud) {
                 AzureVMCloud azureVMCloud = (AzureVMCloud) cloud;
                 synchronized (azureVMCloud) {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMMaintainPoolTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMMaintainPoolTask.java
@@ -34,7 +34,7 @@ public class AzureVMMaintainPoolTask extends AsyncPeriodicWork {
             return;
         }
 
-        for (Computer computer : Jenkins.getInstance().getComputers()) {
+        for (Computer computer : Jenkins.get().getComputers()) {
             if (computer instanceof AzureVMComputer) {
                 AzureVMComputer azureVMComputer = (AzureVMComputer) computer;
                 AzureVMAgent agent = azureVMComputer.getNode();
@@ -75,7 +75,7 @@ public class AzureVMMaintainPoolTask extends AsyncPeriodicWork {
 
     @Override
     public void execute(TaskListener arg0) {
-        for (Cloud cloud : Jenkins.getInstance().clouds) {
+        for (Cloud cloud : Jenkins.get().clouds) {
             if (cloud instanceof AzureVMCloud) {
                 AzureVMCloud azureVMCloud = (AzureVMCloud) cloud;
                 for (AzureVMAgentTemplate template : azureVMCloud.getVmTemplates()) {


### PR DESCRIPTION
https://github.com/jenkinsci/azure-vm-agents-plugin/issues/295 shows that the UI can get blocked by background threads doing maintenance.

I'm still investigating to see what's going on with the background threads and why they're getting stuck.

But for now, the UI should never get blocked when it only needs a read only copy, especially for infrequently updated fields.

This fixes the `configureClouds` page not rendering  and `toggleOffline` functionality from the above issue.

but does not fix the performance issues I would expect.

I've done minor testing to make sure that updates still work.

(also included some miscellaneous cleanup) 