### PR TITLE
Some performance optimisations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.17</version>
+        <version>4.29</version>
     </parent>
 
     <artifactId>azure-vm-agents</artifactId>
@@ -53,15 +53,15 @@
         <findbugs.failOnError>true</findbugs.failOnError>
         <findbugs.excludeFilterFile>findbugs-exclude.xml</findbugs.excludeFilterFile>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <azure-credentials.version>181.v00b0d97d2686</azure-credentials.version>
+        <azure-credentials.version>197.v2f5ab5b82264</azure-credentials.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.263.x</artifactId>
-                <version>807.v6d348e44c987</version>
+                <artifactId>bom-2.277.x</artifactId>
+                <version>966.v3857b7c82032</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>azure-sdk</artifactId>
-            <version>7.va79ea0a60157</version>
+            <version>48.veb7555463c4b</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -38,6 +38,7 @@ import com.microsoft.azure.vmagent.util.AzureClientHolder;
 import com.microsoft.azure.vmagent.util.AzureUtil;
 import com.microsoft.azure.vmagent.util.Constants;
 import com.microsoft.azure.vmagent.util.FailureStage;
+import com.microsoft.jenkins.credentials.AzureResourceManagerCache;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.RelativePath;
@@ -1398,7 +1399,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
             resourceGroupReferenceType = null;
 
             try {
-                AzureResourceManager azureClient = AzureClientHolder.get(azureCredentialsId);
+                AzureResourceManager azureClient = AzureResourceManagerCache.get(azureCredentialsId);
                 String resourceGroupName = AzureVMCloud.getResourceGroupName(
                         resourceGroupReferenceType, newResourceGroupName, existingResourceGroupName);
                 PagedIterable<AvailabilitySet> availabilitySets = azureClient.availabilitySets()
@@ -1475,7 +1476,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
             resourceGroupReferenceType = null;
 
             try {
-                AzureResourceManager azureClient = AzureClientHolder.get(azureCredentialsId);
+                AzureResourceManager azureClient = AzureResourceManagerCache.get(azureCredentialsId);
 
                 String resourceGroupName = AzureVMCloud.getResourceGroupName(
                         resourceGroupReferenceType, newResourceGroupName, existingResourceGroupName);

--- a/src/main/java/com/microsoft/azure/vmagent/util/AzureClientHolder.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/AzureClientHolder.java
@@ -1,33 +1,13 @@
 package com.microsoft.azure.vmagent.util;
 
-import com.azure.resourcemanager.AzureResourceManager;
 import com.microsoft.azure.vmagent.AzureVMManagementServiceDelegate;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.commons.lang.StringUtils;
+import com.microsoft.jenkins.credentials.AzureResourceManagerCache;
 
-/**
- * The Azure client cache holder for the configuration page, where the VMCloud objects may not exist.
- */
 public final class AzureClientHolder {
-    private static String cachedId;
-    private static AzureResourceManager cachedClient;
-
     private AzureClientHolder() {
     }
 
-    @NonNull
-    public static synchronized AzureResourceManager get(String credentialId) {
-        if (credentialId == null) {
-            throw new NullPointerException("credentialId is null!");
-        }
-        if (!StringUtils.equals(cachedId, credentialId)) {
-            cachedId = credentialId;
-            cachedClient = AzureClientUtil.getClient(credentialId);
-        }
-        return cachedClient;
-    }
-
     public static AzureVMManagementServiceDelegate getDelegate(String credentialId) {
-        return AzureVMManagementServiceDelegate.getInstance(get(credentialId), credentialId);
+        return AzureVMManagementServiceDelegate.getInstance(AzureResourceManagerCache.get(credentialId), credentialId);
     }
 }

--- a/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
@@ -23,6 +23,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
+import com.microsoft.jenkins.credentials.AzureResourceManagerCache;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
@@ -463,7 +464,7 @@ public final class AzureUtil {
         if (StringUtils.isEmpty(subscriptionId)) {
             return true;
         }
-        AzureResourceManager defaultClient = AzureClientUtil.getClient(credentialId);
+        AzureResourceManager defaultClient = AzureResourceManagerCache.get(credentialId);
         PagedIterable<Subscription> subscriptions = defaultClient.subscriptions().list();
         boolean isSubscriptionIdValid = false;
         for (Subscription subscription : subscriptions) {

--- a/src/test/java/com/microsoft/azure/vmagent/test/AzureClientUtil.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/AzureClientUtil.java
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-package com.microsoft.azure.vmagent.util;
+package com.microsoft.azure.vmagent.test;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.management.profile.AzureProfile;
@@ -22,6 +22,7 @@ import com.microsoft.azure.util.AzureBaseCredentials;
 import com.microsoft.azure.util.AzureCredentialUtil;
 import com.microsoft.azure.util.AzureCredentials;
 import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
+import com.microsoft.azure.vmagent.util.AzureUtil;
 import hudson.Util;
 import io.jenkins.plugins.azuresdk.HttpClientRetriever;
 

--- a/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
@@ -47,7 +47,6 @@ import com.microsoft.azure.vmagent.AzureVMCloud;
 import com.microsoft.azure.vmagent.AzureVMDeploymentInfo;
 import com.microsoft.azure.vmagent.AzureVMManagementServiceDelegate;
 import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
-import com.microsoft.azure.vmagent.util.AzureClientUtil;
 import com.microsoft.azure.vmagent.util.Constants;
 import hudson.util.Secret;
 import org.junit.After;


### PR DESCRIPTION
* Reduce login calls to absolute minimum
* Reduce sleep from 60 seconds to 10 seconds between attempts, from my local testing the VM instance I'm using is normally ready after 20 seconds
* Login call optimisation fixes log spam for `getToken()`
* Swap expected errors on VM start to just log message and show error on `FINE` log level