### PR TITLE
Improve config-as-code support (breaking change for config-as-code users only)

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -255,7 +255,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
     private String diskType;
 
-    private final boolean ephemeralOSDisk;
+    private boolean ephemeralOSDisk;
 
     private int osDiskSize;
 
@@ -271,7 +271,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
     private Node.Mode usageMode;
 
-    private final boolean shutdownOnIdle;
+    private boolean shutdownOnIdle;
 
     // Image Configuration
     private String imageTopLevelType;
@@ -322,7 +322,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
     // Indicates whether the template is disabled.
     // If disabled, will not attempt to verify or use
-    private final boolean templateDisabled;
+    private boolean templateDisabled;
 
     private String templateStatusDetails;
 
@@ -338,11 +338,11 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
     private boolean doNotUseMachineIfInitFails;
 
-    private final boolean enableMSI;
+    private boolean enableMSI;
 
-    private final boolean enableUAMI;
+    private boolean enableUAMI;
 
-    private final String uamiID;
+    private String uamiID;
 
     private String javaPath;
 
@@ -384,37 +384,25 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
             String newStorageAccountName,
             String existingStorageAccountName,
             String diskType,
-            boolean ephemeralOSDisk,
-            int osDiskSize,
             String noOfParallelJobs,
-            String usageMode,
-            String builtInImage,
-            boolean installGit,
-            boolean installMaven,
-            boolean installDocker,
+            Node.Mode usageMode,
             String osType,
             String imageTopLevelType,
             ImageReferenceTypeClass imageReference,
             String agentLaunchMethod,
-            boolean preInstallSsh,
             String initScript,
             String terminateScript,
             String credentialsId,
             String virtualNetworkName,
             String virtualNetworkResourceGroupName,
             String subnetName,
-            boolean usePrivateIP,
             String nsgName,
             String agentWorkspace,
             String jvmOptions,
             RetentionStrategy retentionStrategy,
-            boolean shutdownOnIdle,
-            boolean templateDisabled,
             boolean executeInitScriptAsRoot,
-            boolean doNotUseMachineIfInitFails,
-            boolean enableMSI,
-            boolean enableUAMI,
-            String uamiID) {
+            boolean doNotUseMachineIfInitFails
+    ) {
         this.templateName = templateName;
         this.templateDesc = templateDesc;
         this.labels = labels;
@@ -431,8 +419,6 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         this.existingStorageAccountName = existingStorageAccountName;
         this.storageAccountNameReferenceType = storageAccountNameReferenceType;
         this.diskType = diskType;
-        this.ephemeralOSDisk = ephemeralOSDisk;
-        this.osDiskSize = osDiskSize;
 
         if (StringUtils.isBlank(noOfParallelJobs) || !noOfParallelJobs.matches(Constants.REG_EX_DIGIT)
                 || noOfParallelJobs.
@@ -443,38 +429,23 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         }
         setUsageMode(usageMode);
         this.imageTopLevelType = imageTopLevelType;
-        this.builtInImage = builtInImage;
-        this.installDocker = installDocker;
-        this.installGit = installGit;
-        this.installMaven = installMaven;
         this.imageReference = imageReference;
         if (imageReference == null) {
             this.imageReference = new ImageReferenceTypeClass();
         }
         this.osType = osType;
-        this.shutdownOnIdle = shutdownOnIdle;
         this.initScript = initScript;
         this.terminateScript = terminateScript;
         this.agentLaunchMethod = agentLaunchMethod;
-        this.preInstallSsh = preInstallSsh;
         this.credentialsId = credentialsId;
         this.virtualNetworkName = virtualNetworkName;
         this.virtualNetworkResourceGroupName = virtualNetworkResourceGroupName;
         this.subnetName = subnetName;
-        this.usePrivateIP = usePrivateIP;
         this.nsgName = nsgName;
         this.agentWorkspace = agentWorkspace;
         this.jvmOptions = jvmOptions;
         this.executeInitScriptAsRoot = executeInitScriptAsRoot;
         this.doNotUseMachineIfInitFails = doNotUseMachineIfInitFails;
-        this.enableMSI = enableMSI;
-        this.enableUAMI = enableUAMI;
-        if (enableUAMI) {
-            this.uamiID = uamiID;
-        } else {
-            this.uamiID = null;
-        }
-        this.templateDisabled = templateDisabled;
         this.templateStatusDetails = "";
 
         // Reset the template verification status.
@@ -483,6 +454,11 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
         // Forms data which is not persisted
         labelDataSet = Label.parse(labels);
+    }
+
+    @DataBoundSetter
+    public void setBuiltInImage(String builtInImage) {
+        this.builtInImage = builtInImage;
     }
 
     /**
@@ -918,6 +894,16 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         return ephemeralOSDisk;
     }
 
+    @DataBoundSetter
+    public void setEphemeralOSDisk(boolean ephemeralOSDisk) {
+        this.ephemeralOSDisk = ephemeralOSDisk;
+    }
+
+    @DataBoundSetter
+    public void setOsDiskSize(int osDiskSize) {
+        this.osDiskSize = osDiskSize;
+    }
+
     public int getOsDiskSize() {
         return osDiskSize;
     }
@@ -938,8 +924,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         return existingStorageAccountName;
     }
 
-    public Node.Mode getUseAgentAlwaysIfAvail() {
-        return (usageMode == null) ? Node.Mode.NORMAL : usageMode;
+    public Node.Mode getUsageMode() {
+        return usageMode == null ? Node.Mode.NORMAL : usageMode;
     }
 
     public boolean isStorageAccountNameReferenceTypeEquals(String type) {
@@ -949,19 +935,14 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         return type != null && type.equalsIgnoreCase(this.storageAccountNameReferenceType);
     }
 
-    public String getUsageMode() {
-        return getUseAgentAlwaysIfAvail().getDescription();
+    @DataBoundSetter
+    public void setUsageMode(Node.Mode usageMode) {
+        this.usageMode = usageMode;
     }
 
-    public void setUsageMode(String mode) {
-        Node.Mode val = Node.Mode.NORMAL;
-        for (Node.Mode m : hudson.Functions.getNodeModes()) {
-            if (mode.equalsIgnoreCase(m.getDescription())) {
-                val = m;
-                break;
-            }
-        }
-        this.usageMode = val;
+    @DataBoundSetter
+    public void setShutdownOnIdle(boolean shutdownOnIdle) {
+        this.shutdownOnIdle = shutdownOnIdle;
     }
 
     public boolean isShutdownOnIdle() {
@@ -984,6 +965,21 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         return builtInImage;
     }
 
+    @DataBoundSetter
+    public void setInstallGit(boolean installGit) {
+        this.installGit = installGit;
+    }
+
+    @DataBoundSetter
+    public void setInstallMaven(boolean installMaven) {
+        this.installMaven = installMaven;
+    }
+
+    @DataBoundSetter
+    public void setInstallDocker(boolean installDocker) {
+        this.installDocker = installDocker;
+    }
+
     public boolean isInstallGit() {
         return installGit;
     }
@@ -1000,7 +996,12 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         return osType;
     }
 
-    public boolean getPreInstallSsh() {
+    @DataBoundSetter
+    public void setPreInstallSsh(boolean preInstallSsh) {
+        this.preInstallSsh = preInstallSsh;
+    }
+
+    public boolean isPreInstallSsh() {
         return preInstallSsh;
     }
 
@@ -1038,6 +1039,11 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
     public void setSubnetName(String subnetName) {
         this.subnetName = subnetName;
+    }
+
+    @DataBoundSetter
+    public void setUsePrivateIP(boolean usePrivateIP) {
+        this.usePrivateIP = usePrivateIP;
     }
 
     public boolean getUsePrivateIP() {
@@ -1105,6 +1111,11 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         return this.templateDisabled;
     }
 
+    @DataBoundSetter
+    public void setTemplateDisabled(boolean templateDisabled) {
+        this.templateDisabled = templateDisabled;
+    }
+
     /**
      * Is the template set up and verified?
      *
@@ -1156,18 +1167,34 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         return doNotUseMachineIfInitFails;
     }
 
+    @DataBoundSetter
+    public void setEnableMSI(boolean enableMSI) {
+        this.enableMSI = enableMSI;
+    }
+
     public boolean isEnableMSI() {
         return enableMSI;
+    }
+
+    @DataBoundSetter
+    public void setEnableUAMI(boolean enableUAMI) {
+        this.enableUAMI = enableUAMI;
     }
 
     public boolean isEnableUAMI() {
         return enableUAMI;
     }
 
+    @DataBoundSetter
+    public void setUamiID(String uamiID) {
+        this.uamiID = uamiID;
+    }
+
     public String getUamiID() {
         return uamiID;
     }
 
+    @DataBoundSetter
     public void setDoNotUseMachineIfInitFails(boolean doNotUseMachineIfInitFails) {
         this.doNotUseMachineIfInitFails = doNotUseMachineIfInitFails;
     }
@@ -1192,7 +1219,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
                 .withNumberOfExecutors(String.valueOf(getNoOfParallelJobs()))
                 .withOsType(getOsType())
                 .withLaunchMethod(getAgentLaunchMethod())
-                .withPreInstallSsh(getPreInstallSsh())
+                .withPreInstallSsh(isPreInstallSsh())
                 .withInitScript(getInitScript())
                 .withVirtualNetworkName(getVirtualNetworkName())
                 .withVirtualNetworkResourceGroupName(getVirtualNetworkResourceGroupName())

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -423,14 +423,14 @@ public class AzureVMCloud extends Cloud {
             LOGGER.log(Level.FINE,
                     "AzureVMCloud: getAzureAgentTemplate: Found agent template {0}",
                     agentTemplate.getTemplateName());
-            if (agentTemplate.getUseAgentAlwaysIfAvail() == Node.Mode.NORMAL) {
+            if (agentTemplate.getUsageMode() == Node.Mode.NORMAL) {
                 if (label == null || label.matches(agentTemplate.getLabelDataSet())) {
                     LOGGER.log(Level.FINE,
                             "AzureVMCloud: getAzureAgentTemplate: {0} matches!",
                             agentTemplate.getTemplateName());
                     return agentTemplate;
                 }
-            } else if (agentTemplate.getUseAgentAlwaysIfAvail() == Node.Mode.EXCLUSIVE) {
+            } else if (agentTemplate.getUsageMode() == Node.Mode.EXCLUSIVE) {
                 if (label != null && label.matches(agentTemplate.getLabelDataSet())) {
                     LOGGER.log(Level.FINE,
                             "AzureVMCloud: getAzureAgentTemplate: {0} matches!",

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -257,7 +257,7 @@ public final class AzureVMManagementServiceDelegate {
             final boolean preInstallSshInWindows = properties.get("osType").equals(Constants.OS_TYPE_WINDOWS)
                     && properties.get("agentLaunchMethod").equals(Constants.LAUNCH_METHOD_SSH)
                     && (isBasic || referenceType == ImageReferenceType.REFERENCE
-                    || template.getPreInstallSsh());
+                    || template.isPreInstallSsh());
 
             final boolean useCustomScriptExtension
                     = preInstallSshInWindows
@@ -1076,7 +1076,7 @@ public final class AzureVMManagementServiceDelegate {
                     osType,
                     template.getAgentWorkspace(),
                     (int) properties.get("noOfParallelJobs"),
-                    template.getUseAgentAlwaysIfAvail(),
+                    template.getUsageMode(),
                     template.getLabels(),
                     template.retrieveAzureCloudReference().getDisplayName(),
                     template.getCredentialsId(),

--- a/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateBuilder.java
+++ b/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateBuilder.java
@@ -75,7 +75,7 @@ public class AzureVMTemplateBuilder extends AzureVMTemplateFluent<AzureVMTemplat
     }
 
     public AzureVMAgentTemplate build() {
-        return new AzureVMAgentTemplate(
+        AzureVMAgentTemplate azureVMAgentTemplate = new AzureVMAgentTemplate(
                 fluent.getName(),
                 fluent.getDescription(),
                 fluent.getLabels(),
@@ -87,14 +87,8 @@ public class AzureVMTemplateBuilder extends AzureVMTemplateFluent<AzureVMTemplat
                 fluent.getNewStorageAccountName(),
                 fluent.getExistingStorageAccountName(),
                 fluent.getDiskType(),
-                fluent.isEphemeralOSDisk(),
-                fluent.getOsDiskSize(),
                 fluent.getAdvancedImage().getNoOfParallelJobs(),
                 fluent.getUsageMode(),
-                fluent.getBuiltInImage().getBuiltInImage(),
-                fluent.getBuiltInImage().isInstallGit(),
-                fluent.getBuiltInImage().isInstallMaven(),
-                fluent.getBuiltInImage().isInstallDocker(),
                 fluent.getAdvancedImage().getOsType(),
                 fluent.getImageTopLevelType(),
                 new AzureVMAgentTemplate.ImageReferenceTypeClass(fluent.getAdvancedImage().getImage(),
@@ -109,24 +103,32 @@ public class AzureVMTemplateBuilder extends AzureVMTemplateFluent<AzureVMTemplat
                         fluent.getAdvancedImage().getGallerySubscriptionId(),
                         fluent.getAdvancedImage().getGalleryResourceGroup()),
                 fluent.getAdvancedImage().getAgentLaunchMethod(),
-                fluent.getAdvancedImage().isPreInstallSsh(),
                 fluent.getAdvancedImage().getInitScript(),
                 fluent.getAdvancedImage().getTerminateScript(),
                 fluent.getCredentialsId(),
                 fluent.getAdvancedImage().getVirtualNetworkName(),
                 fluent.getAdvancedImage().getVirtualNetworkResourceGroupName(),
                 fluent.getAdvancedImage().getSubnetName(),
-                fluent.getAdvancedImage().isUsePrivateIP(),
                 fluent.getAdvancedImage().getNsgName(),
                 fluent.getWorkspace(),
                 fluent.getAdvancedImage().getJvmOptions(),
                 fluent.getRetentionStrategy(),
-                fluent.isShutdownOnIdle(),
-                fluent.getAdvancedImage().isTemplateDisabled(),
                 fluent.getAdvancedImage().isExecuteInitScriptAsRoot(),
-                fluent.getAdvancedImage().isDoNotUseMachineIfInitFails(),
-                fluent.getAdvancedImage().isEnableMSI(),
-                fluent.getAdvancedImage().isEnableUAMI(),
-                fluent.getAdvancedImage().getUamiID());
+                fluent.getAdvancedImage().isDoNotUseMachineIfInitFails()
+                );
+        azureVMAgentTemplate.setShutdownOnIdle(fluent.isShutdownOnIdle());
+        azureVMAgentTemplate.setEphemeralOSDisk(fluent.isEphemeralOSDisk());
+        azureVMAgentTemplate.setOsDiskSize(fluent.getOsDiskSize());
+        azureVMAgentTemplate.setTemplateDisabled(fluent.getAdvancedImage().isTemplateDisabled());
+        azureVMAgentTemplate.setBuiltInImage(fluent.getBuiltInImage().getBuiltInImage());
+        azureVMAgentTemplate.setInstallGit(fluent.getBuiltInImage().isInstallGit());
+        azureVMAgentTemplate.setInstallMaven(fluent.getBuiltInImage().isInstallMaven());
+        azureVMAgentTemplate.setInstallDocker(fluent.getBuiltInImage().isInstallDocker());
+        azureVMAgentTemplate.setUsePrivateIP(fluent.getAdvancedImage().isUsePrivateIP());
+        azureVMAgentTemplate.setEnableMSI(fluent.getAdvancedImage().isEnableMSI());
+        azureVMAgentTemplate.setEnableUAMI(fluent.getAdvancedImage().isEnableUAMI());
+        azureVMAgentTemplate.setUamiID(fluent.getAdvancedImage().getUamiID());
+        azureVMAgentTemplate.setPreInstallSsh(fluent.getAdvancedImage().isPreInstallSsh());
+        return azureVMAgentTemplate;
     }
 }

--- a/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateFluent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateFluent.java
@@ -4,6 +4,7 @@ import com.microsoft.azure.vmagent.AzureVMCloudBaseRetentionStrategy;
 import com.microsoft.azure.vmagent.AzureVMCloudPoolRetentionStrategy;
 import com.microsoft.azure.vmagent.AzureVMCloudRetensionStrategy;
 import com.microsoft.azure.vmagent.util.Constants;
+import hudson.model.Node;
 
 public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
 
@@ -39,7 +40,7 @@ public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
 
     private boolean shutdownOnIdle;
 
-    private String usageMode;
+    private Node.Mode usageMode;
 
     private String imageTopLevelType;
 
@@ -58,7 +59,7 @@ public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
         osDiskSize = 0;
         retentionStrategy = new AzureVMCloudRetensionStrategy(Constants.DEFAULT_IDLE_RETENTION_TIME);
         shutdownOnIdle = false;
-        usageMode = "Use this node as much as possible";
+        usageMode = Node.Mode.NORMAL;
         imageTopLevelType = Constants.IMAGE_TOP_LEVEL_BASIC;
         availability = new AvailabilityBuilder().build();
         builtInImage = new BuiltInImageBuilder().build();
@@ -154,7 +155,7 @@ public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
         return (T) this;
     }
 
-    public T withUsageMode(String usageMode) {
+    public T withUsageMode(Node.Mode usageMode) {
         this.usageMode = usageMode;
         return (T) this;
     }
@@ -257,7 +258,7 @@ public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
         return shutdownOnIdle;
     }
 
-    public String getUsageMode() {
+    public Node.Mode getUsageMode() {
         return usageMode;
     }
 

--- a/src/main/java/com/microsoft/azure/vmagent/util/TemplateUtil.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/TemplateUtil.java
@@ -39,7 +39,7 @@ public final class TemplateUtil {
                 && StringUtils.equals(a.getImageReference().getVersion(),
                 b.getImageReference().getVersion())
                 && StringUtils.equals(a.getAgentLaunchMethod(), b.getAgentLaunchMethod())
-                && a.getPreInstallSsh() == b.getPreInstallSsh()
+                && a.isPreInstallSsh() == b.isPreInstallSsh()
                 && StringUtils.equals(a.getInitScript(), b.getInitScript())
                 && StringUtils.equals(a.getTerminateScript(), b.getTerminateScript())
                 && a.getExecuteInitScriptAsRoot() == b.getExecuteInitScriptAsRoot()

--- a/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMCloud.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/ITAzureVMCloud.java
@@ -90,7 +90,7 @@ public class ITAzureVMCloud extends IntegrationTest {
             when(templateMock.getTemplateDesc()).thenReturn(templateDesc);
             when(templateMock.getAgentWorkspace()).thenReturn(agentWorkspace);
             when(templateMock.getNoOfParallelJobs()).thenReturn(noOfParallelJobs);
-            when(templateMock.getUseAgentAlwaysIfAvail()).thenReturn(useAgentAlwaysIfAvail);
+            when(templateMock.getUsageMode()).thenReturn(useAgentAlwaysIfAvail);
             when(templateMock.getLabels()).thenReturn(templateLabels);
             when(templateMock.getCredentialsId()).thenReturn(credentialsId);
             when(templateMock.getJvmOptions()).thenReturn(jvmOptions);

--- a/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/IntegrationTest.java
@@ -403,7 +403,7 @@ public class IntegrationTest {
         when(templateMock.getOsDiskStorageAccountType()).thenReturn(storageType);
         when(templateMock.getDiskType()).thenReturn(Constants.DISK_MANAGED);
         when(templateMock.getOsDiskSize()).thenReturn(testEnv.osDiskSize);
-        when(templateMock.getPreInstallSsh()).thenReturn(true);
+        when(templateMock.isPreInstallSsh()).thenReturn(true);
         when(templateMock.isEnableMSI()).thenReturn(enableMSI);
         when(templateMock.isEnableUAMI()).thenReturn(enableUAMI);
         when(templateMock.isEphemeralOSDisk()).thenReturn(ephemeralOSDisk);

--- a/src/test/java/com/microsoft/azure/vmagent/test/jcasc/AdvancedConfigAsCodeTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/jcasc/AdvancedConfigAsCodeTest.java
@@ -4,6 +4,7 @@ import com.microsoft.azure.vmagent.AzureTagPair;
 import com.microsoft.azure.vmagent.AzureVMAgentTemplate;
 import com.microsoft.azure.vmagent.AzureVMCloud;
 import com.microsoft.azure.vmagent.AzureVMCloudRetensionStrategy;
+import hudson.model.Node;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -76,7 +77,7 @@ public class AdvancedConfigAsCodeTest {
         assertThat(template.getOsDiskSize(), is(40));
         assertThat(template.getOsType(), is("Linux"));
 
-        assertThat(template.getPreInstallSsh(), is(false));
+        assertThat(template.isPreInstallSsh(), is(false));
 
         AzureVMCloudRetensionStrategy retentionStrategy = (AzureVMCloudRetensionStrategy) template.getRetentionStrategy();
         assertThat(retentionStrategy.getIdleTerminationMinutes(), is(40L));
@@ -89,7 +90,7 @@ public class AdvancedConfigAsCodeTest {
         assertThat(template.isTemplateDisabled(), is(false));
         assertThat(template.getTemplateName(), is("azure"));
 
-        assertThat(template.getUsageMode(), is("Use this node as much as possible"));
+        assertThat(template.getUsageMode(), is(Node.Mode.NORMAL));
         assertThat(template.getUsePrivateIP(), is(true));
 
         assertThat(template.getVirtualMachineSize(), is("Standard_A2"));

--- a/src/test/java/com/microsoft/azure/vmagent/test/jcasc/BasicConfigAsCodeTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/test/jcasc/BasicConfigAsCodeTest.java
@@ -3,6 +3,7 @@ package com.microsoft.azure.vmagent.test.jcasc;
 import com.microsoft.azure.vmagent.AzureVMAgentTemplate;
 import com.microsoft.azure.vmagent.AzureVMCloud;
 import com.microsoft.azure.vmagent.AzureVMCloudRetensionStrategy;
+import hudson.model.Node;
 import io.jenkins.plugins.casc.ConfigurationContext;
 import io.jenkins.plugins.casc.ConfiguratorRegistry;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -68,7 +69,7 @@ public class BasicConfigAsCodeTest {
         assertThat(template.getOsDiskSize(), is(0));
         assertThat(template.getOsType(), is("Linux"));
 
-        assertThat(template.getPreInstallSsh(), is(true));
+        assertThat(template.isPreInstallSsh(), is(true));
 
         AzureVMCloudRetensionStrategy retentionStrategy = (AzureVMCloudRetensionStrategy) template.getRetentionStrategy();
         assertThat(retentionStrategy.getIdleTerminationMinutes(), is(60L));
@@ -81,7 +82,7 @@ public class BasicConfigAsCodeTest {
         assertThat(template.isTemplateDisabled(), is(false));
         assertThat(template.getTemplateName(), is("ubuntu"));
 
-        assertThat(template.getUsageMode(), is("Use this node as much as possible"));
+        assertThat(template.getUsageMode(), is(Node.Mode.NORMAL));
         assertThat(template.getUsePrivateIP(), is(false));
 
         assertThat(template.getVirtualMachineSize(), is("Standard_DS2_v2"));

--- a/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/advanced.yaml
+++ b/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/advanced.yaml
@@ -54,7 +54,7 @@ jenkins:
             templateDesc: "desc"
             templateDisabled: false
             templateName: "azure"
-            usageMode: "Use this node as much as possible"
+            usageMode: "NORMAL"
             usePrivateIP: true
             virtualMachineSize: "Standard_A2"
             virtualNetworkName: "vm-agent"

--- a/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/basic.yaml
+++ b/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/basic.yaml
@@ -38,6 +38,6 @@ jenkins:
             storageAccountType: "Standard_LRS"
             templateDisabled: false
             templateName: "ubuntu"
-            usageMode: "Use this node as much as possible"
+            usageMode: "NORMAL"
             usePrivateIP: false
             virtualMachineSize: "Standard_DS2_v2"

--- a/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/expectedAdvanced.yaml
+++ b/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/expectedAdvanced.yaml
@@ -17,9 +17,6 @@
       credentialsId: "admin-cred"
       diskType: "managed"
       doNotUseMachineIfInitFails: true
-      enableMSI: false
-      enableUAMI: false
-      ephemeralOSDisk: false
       executeInitScriptAsRoot: true
       imageReference:
         galleryImageDefinition: "Linux"
@@ -32,9 +29,6 @@
         yum install -y java
         yum install -y nodejs
         cat /etc/hosts
-      installDocker: false
-      installGit: false
-      installMaven: false
       jvmOptions: "-xmx"
       labels: "linux"
       location: "UK South"
@@ -43,18 +37,15 @@
       nsgName: "an-nsg"
       osDiskSize: 40
       osType: "Linux"
-      preInstallSsh: false
       retentionStrategy:
         azureVMCloudRetentionStrategy:
           idleTerminationMinutes: 40
-      shutdownOnIdle: false
       storageAccountNameReferenceType: "new"
       storageAccountType: "Standard_LRS"
       subnetName: "jenkins"
       templateDesc: "desc"
-      templateDisabled: false
       templateName: "azure"
-      usageMode: "Use this node as much as possible"
+      usageMode: NORMAL
       usePrivateIP: true
       virtualMachineSize: "Standard_A2"
       virtualNetworkName: "vm-agent"

--- a/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/expectedBasic.yaml
+++ b/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/expectedBasic.yaml
@@ -11,9 +11,6 @@
       credentialsId: "admin-cred"
       diskType: "managed"
       doNotUseMachineIfInitFails: true
-      enableMSI: false
-      enableUAMI: false
-      ephemeralOSDisk: false
       executeInitScriptAsRoot: true
       imageReference:
         version: "latest"
@@ -25,17 +22,13 @@
       location: "East US"
       newStorageAccountName: "agent-storage"
       noOfParallelJobs: 1
-      osDiskSize: 0
       osType: "Linux"
       preInstallSsh: true
       retentionStrategy:
         azureVMCloudRetentionStrategy:
           idleTerminationMinutes: 60
-      shutdownOnIdle: false
       storageAccountNameReferenceType: "new"
       storageAccountType: "Standard_LRS"
-      templateDisabled: false
       templateName: "ubuntu"
-      usageMode: "Use this node as much as possible"
-      usePrivateIP: false
+      usageMode: NORMAL
       virtualMachineSize: "Standard_DS2_v2"


### PR DESCRIPTION
Configuration as code users after updating the plugin need to update their config file for `usageMode`
There are two possible values:
- `Use this node as much as possible`
  - now: `NORMAL`

- `Only build jobs with label expressions matching this node`
  - now: `EXCLUSIVE`

This fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/301
Which prevented the exported configuration working for users with a non english locale (and a translated usage mode). The configuration now matches Jenkins core and other plugins that configure the usage mode.

The following fields are now optional, you don't need to specify them if you are using the default value:
- `enableMSI`
- `enableUAMI`
- `ephemeralOSDisk`
- `preInstallSsh`
- `shutdownOnIdle`
- `templateDisabled`

The `builtInImage` is only required now if you are using a built-in image

