### PR TITLE
Add Windows Server 2022 to built in images

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -1544,6 +1544,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
             ListBoxModel model = new ListBoxModel();
             model.add(Constants.UBUNTU_2004_LTS);
             model.add(Constants.UBUNTU_1604_LTS);
+            model.add(Constants.WINDOWS_SERVER_2022);
             model.add(Constants.WINDOWS_SERVER_2019);
             model.add(Constants.WINDOWS_SERVER_2016);
             return model;

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -1408,45 +1408,49 @@ public final class AzureVMManagementServiceDelegate {
 
     private static Map<String, Map<String, String>> getDefaultImageProperties() {
         final Map<String, Map<String, String>> imageProperties = new HashMap<>();
-        imageProperties.put(Constants.WINDOWS_SERVER_2016, new HashMap<>());
-        imageProperties.put(Constants.WINDOWS_SERVER_2019, new HashMap<>());
-        imageProperties.put(Constants.UBUNTU_1604_LTS, new HashMap<>());
-        imageProperties.put(Constants.UBUNTU_2004_LTS, new HashMap<>());
+        imageProperties.put(Constants.WINDOWS_SERVER_2016,
+                imageProperties("MicrosoftWindowsServer", "WindowsServer", "2016-Datacenter", "2016-Datacenter-with-Containers", Constants.OS_TYPE_WINDOWS));
+        imageProperties.put(Constants.WINDOWS_SERVER_2019,
+                imageProperties("MicrosoftWindowsServer", "WindowsServer", "2019-Datacenter", "2019-Datacenter-with-Containers", Constants.OS_TYPE_WINDOWS));
+        imageProperties.put(Constants.WINDOWS_SERVER_2022,
+                imageProperties("MicrosoftWindowsServer", "WindowsServer", "2022-datacenter-azure-edition-core", "2022-datacenter-azure-edition-core", Constants.OS_TYPE_WINDOWS));
+        imageProperties.put(Constants.UBUNTU_1604_LTS,
+                imageProperties("Canonical", "UbuntuServer", "16.04-LTS", "16.04-LTS", Constants.OS_TYPE_LINUX));
+        imageProperties.put(Constants.UBUNTU_2004_LTS,
+                imageProperties("canonical", "0001-com-ubuntu-server-focal", "20_04-lts-gen2", "20_04-lts-gen2", Constants.OS_TYPE_LINUX));
 
-        imageProperties(imageProperties, Constants.WINDOWS_SERVER_2016, "MicrosoftWindowsServer", "WindowsServer", "2016-Datacenter", "2016-Datacenter-with-Containers", Constants.OS_TYPE_WINDOWS);
-        imageProperties(imageProperties, Constants.WINDOWS_SERVER_2019, "MicrosoftWindowsServer", "WindowsServer", "2019-Datacenter", "2019-Datacenter-with-Containers", Constants.OS_TYPE_WINDOWS);
-        imageProperties(imageProperties, Constants.UBUNTU_1604_LTS, "Canonical", "UbuntuServer", "16.04-LTS", "16.04-LTS", Constants.OS_TYPE_LINUX);
-        imageProperties(imageProperties, Constants.UBUNTU_2004_LTS, "canonical", "0001-com-ubuntu-server-focal", "20_04-lts-gen2", "20_04-lts-gen2", Constants.OS_TYPE_LINUX);
         return imageProperties;
     }
 
-    private static void imageProperties(
-            Map<String, Map<String, String>> imageProperties,
-            String imageName,
+    private static Map<String, String> imageProperties(
             String defaultImagePublisher,
             String offer,
             String sku,
             String dockerImageSku,
             String osType
     ) {
-        imageProperties.get(imageName).put(Constants.DEFAULT_IMAGE_PUBLISHER, defaultImagePublisher);
-        imageProperties.get(imageName).put(Constants.DEFAULT_IMAGE_OFFER, offer);
-        imageProperties.get(imageName).put(Constants.DEFAULT_IMAGE_SKU, sku);
-        imageProperties.get(imageName).put(Constants.DEFAULT_DOCKER_IMAGE_SKU, dockerImageSku);
-        imageProperties.get(imageName).put(Constants.DEFAULT_IMAGE_VERSION, "latest");
-        imageProperties.get(imageName).put(Constants.DEFAULT_OS_TYPE, osType);
-        imageProperties.get(imageName).put(Constants.DEFAULT_LAUNCH_METHOD, Constants.LAUNCH_METHOD_SSH);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Constants.DEFAULT_IMAGE_PUBLISHER, defaultImagePublisher);
+        properties.put(Constants.DEFAULT_IMAGE_OFFER, offer);
+        properties.put(Constants.DEFAULT_IMAGE_SKU, sku);
+        properties.put(Constants.DEFAULT_DOCKER_IMAGE_SKU, dockerImageSku);
+        properties.put(Constants.DEFAULT_IMAGE_VERSION, "latest");
+        properties.put(Constants.DEFAULT_OS_TYPE, osType);
+        properties.put(Constants.DEFAULT_LAUNCH_METHOD, Constants.LAUNCH_METHOD_SSH);
+        return properties;
     }
 
     private static Map<String, Map<String, String>> getPreInstalledToolsScript() {
         final Map<String, Map<String, String>> tools = new HashMap<>();
         tools.put(Constants.WINDOWS_SERVER_2016, new HashMap<>());
         tools.put(Constants.WINDOWS_SERVER_2019, new HashMap<>());
+        tools.put(Constants.WINDOWS_SERVER_2022, new HashMap<>());
         tools.put(Constants.UBUNTU_1604_LTS, new HashMap<>());
         tools.put(Constants.UBUNTU_2004_LTS, new HashMap<>());
         try {
             windows(Constants.WINDOWS_SERVER_2016, tools);
             windows(Constants.WINDOWS_SERVER_2019, tools);
+            windows(Constants.WINDOWS_SERVER_2022, tools);
             ubuntu(Constants.UBUNTU_1604_LTS, tools);
             ubuntu(Constants.UBUNTU_2004_LTS, tools);
 

--- a/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
@@ -116,6 +116,7 @@ public final class Constants {
     /**
      * Built In Image.
      */
+    public static final String WINDOWS_SERVER_2022 = "Windows Server 2022";
     public static final String WINDOWS_SERVER_2019 = "Windows Server 2019";
     public static final String WINDOWS_SERVER_2016 = "Windows Server 2016";
     public static final String UBUNTU_1604_LTS = "Ubuntu 16.04 LTS";

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
@@ -129,11 +129,11 @@
                 </f:entry>
 
                 <f:section title="${%Pre_Installed_Tools}">
-                    <f:entry title="Install Git (Latest)" field="installGit">
+                    <f:entry title="Install Git" field="installGit">
                         <f:checkbox/>
                     </f:entry>
 
-                    <f:entry title="Install Maven (v3.6.3)" field="installMaven">
+                    <f:entry title="Install Maven" field="installMaven">
                         <f:checkbox/>
                     </f:entry>
 

--- a/src/main/resources/scripts/ubuntuInstallMavenScript.sh
+++ b/src/main/resources/scripts/ubuntuInstallMavenScript.sh
@@ -1,6 +1,6 @@
 # Install Maven
 
-MAVEN_VERSION=3.6.3
+MAVEN_VERSION=3.8.4
 
 sudo curl -O https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
 sudo tar zxvf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt/

--- a/src/main/webapp/help-initScript.html
+++ b/src/main/webapp/help-initScript.html
@@ -17,7 +17,7 @@ java -version
 sudo apt-get install -y git
 
 # Install Maven
-MAVEN_VERSION=3.6.3
+MAVEN_VERSION=3.8.4
 
 sudo curl -O https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
 sudo tar zxvf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt/


### PR DESCRIPTION
1. Docker pre-install doesn't do anything, maybe a follow up for later
2. Nodes UI will say it's 2019 unless you're running the latest Java version at this time: https://issues.jenkins.io/browse/JENKINS-67634