### PR TITLE
Bump template apiVersion to 2020-06-01

### DIFF
--- a/src/main/resources/customImageTemplate.json
+++ b/src/main/resources/customImageTemplate.json
@@ -47,7 +47,7 @@
             }
         },
         {
-            "apiVersion": "2019-03-01",
+            "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",

--- a/src/main/resources/customImageTemplateWithManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithManagedDisk.json
@@ -68,7 +68,7 @@
             }
         },
         {
-            "apiVersion": "2019-03-01",
+            "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -55,7 +55,7 @@
             }
         },
         {
-            "apiVersion": "2019-03-01",
+            "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -102,7 +102,7 @@
                 {
                     "type": "extensions",
                     "name": "[concat('customScript', variables('vmName'), copyIndex())]",
-                    "apiVersion": "2019-03-01",
+                    "apiVersion": "2020-06-01",
                     "location": "[variables('location')]",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"

--- a/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
@@ -76,7 +76,7 @@
             }
         },
         {
-            "apiVersion": "2019-03-01",
+            "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -122,7 +122,7 @@
                 {
                     "type": "extensions",
                     "name": "[concat('customScript', variables('vmName'), copyIndex())]",
-                    "apiVersion": "2019-03-01",
+                    "apiVersion": "2020-06-01",
                     "location": "[variables('location')]",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"

--- a/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
@@ -48,7 +48,7 @@
             }
         },
         {
-            "apiVersion": "2019-03-01",
+            "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",

--- a/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
@@ -56,7 +56,7 @@
             }
         },
         {
-            "apiVersion": "2019-03-01",
+            "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -101,7 +101,7 @@
                 {
                     "type": "extensions",
                     "name": "[concat('customScript', variables('vmName'), copyIndex())]",
-                    "apiVersion": "2019-03-01",
+                    "apiVersion": "2020-06-01",
                     "location": "[variables('location')]",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -48,7 +48,7 @@
             }
         },
         {
-            "apiVersion": "2019-03-01",
+            "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",

--- a/src/main/resources/referenceImageTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithManagedDisk.json
@@ -48,7 +48,7 @@
             }
         },
         {
-            "apiVersion": "2019-03-01",
+            "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -56,7 +56,7 @@
             }
         },
         {
-            "apiVersion": "2019-03-01",
+            "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -105,7 +105,7 @@
                 {
                     "type": "extensions",
                     "name": "[concat('customScript', variables('vmName'), copyIndex())]",
-                    "apiVersion": "2019-03-01",
+                    "apiVersion": "2020-06-01",
                     "location": "[variables('location')]",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"

--- a/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
@@ -56,7 +56,7 @@
             }
         },
         {
-            "apiVersion": "2019-03-01",
+            "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -104,7 +104,7 @@
                 {
                     "type": "extensions",
                     "name": "[concat('customScript', variables('vmName'), copyIndex())]",
-                    "apiVersion": "2019-03-01",
+                    "apiVersion": "2020-06-01",
                     "location": "[variables('location')]",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"


### PR DESCRIPTION
Use the 2020-06-01 apiVersion to allow deployment of latest v4/v5
instances with Ephemeral OS disk. This fixes deployment errors like
"Ephemeral OS disk is not supported for VM size Standard_D2ads_v5."

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
