### PR TITLE
Allow extended read to view agent configuration

### DIFF
--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMComputer/configure.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMComputer/configure.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
-  <l:layout permission="${app.ADMINISTER}" title="${it.name} Configuration">
+  <l:layout permission="${it.EXTENDED_READ}" title="${it.name} Configuration">
     <st:include page="sidepanel.jelly"/>
     <l:main-panel>
       <f:entry title="${%Name}">


### PR DESCRIPTION
According to https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/hudson/model/Computer/sidepanel.jelly#L36-L37

The permission required to view the Agent page is ExtendedRead.

It was reported to me that someone could see the link but got an Administer required error message when trying to view the page