### PR TITLE
When limiting VMs per template, count template VMs not all cloud VMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bin
 /target
 /work
+/.checkstyle
 
 *.idea
 *.settings

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -661,7 +661,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
         // Adjust estimated virtual machine count.
         AzureVMCloud parentCloud = getCloud();
         if (parentCloud != null) {
-            parentCloud.adjustVirtualMachineCount(-1, template.getMaxVirtualMachinesLimit());
+            parentCloud.adjustApproximateVirtualMachineCount(-1, template);
         }
 
         Jenkins.get().removeNode(this);

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -373,7 +373,7 @@ public class AzureVMCloud extends Cloud {
             int count = 0;
             if (approximateVirtualMachineCountsByTemplate != null) {
                 for (final Integer templateCount : approximateVirtualMachineCountsByTemplate.values()) {
-                    count += templateCount.intValue();
+                    count += templateCount;
                 }
             }
             return count;
@@ -384,7 +384,7 @@ public class AzureVMCloud extends Cloud {
      * Retrieves the current count of the number of virtual machines for a specific
      * template.
      *
-     * @param templateName The name of the template whose VMs are being counted.
+     * @param template the template VMs are being counted for.
      * @return The number of VMs of that template.
      */
     @Restricted(NoExternalUse.class)
@@ -394,7 +394,7 @@ public class AzureVMCloud extends Cloud {
             if (approximateVirtualMachineCountsByTemplate != null) {
                 final Integer templateCount = approximateVirtualMachineCountsByTemplate.get(templateName);
                 if (templateCount != null) {
-                    return templateCount.intValue();
+                    return templateCount;
                 }
             }
             return 0;
@@ -417,7 +417,7 @@ public class AzureVMCloud extends Cloud {
             final int newCount = currentCount + delta;
             if (approximateVirtualMachineCountsByTemplate == null) {
                 if (newCount != 0) {
-                    setCurrentVirtualMachineCount(Collections.singletonMap(templateName, Integer.valueOf(newCount)));
+                    setCurrentVirtualMachineCount(Collections.singletonMap(templateName, newCount));
                 }
             } else {
                 if (newCount == 0) {
@@ -426,7 +426,7 @@ public class AzureVMCloud extends Cloud {
                         approximateVirtualMachineCountsByTemplate = null;
                     }
                 } else {
-                    approximateVirtualMachineCountsByTemplate.put(templateName, Integer.valueOf(newCount));
+                    approximateVirtualMachineCountsByTemplate.put(templateName, newCount);
                 }
             }
         }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -34,6 +34,7 @@ import com.microsoft.azure.vmagent.util.Constants;
 import com.microsoft.azure.vmagent.util.FailureStage;
 import com.microsoft.azure.vmagent.util.PoolLock;
 import com.microsoft.jenkins.credentials.AzureResourceManagerCache;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.init.Initializer;
@@ -56,6 +57,8 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.cloudstats.CloudStatistics;
 import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
 import org.jenkinsci.plugins.cloudstats.TrackedPlannedNode;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -71,6 +74,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
@@ -122,7 +126,8 @@ public class AzureVMCloud extends Cloud {
     private transient String configurationStatus;
 
     // Approximate virtual machine count.  Updated periodically.
-    private int approximateVirtualMachineCount;
+    @CheckForNull
+    private transient Map<String, Integer> approximateVirtualMachineCountsByTemplate;
 
     private transient AzureResourceManager azureClient;
 
@@ -358,74 +363,94 @@ public class AzureVMCloud extends Cloud {
     }
 
     /**
-     * Retrieves the current approximate virtual machine count.
+     * Retrieves the current approximate virtual machine count,
+     * counting only VMs we've made.
      *
      * @return The approximate count
      */
     public int getApproximateVirtualMachineCount() {
         synchronized (this) {
-            return approximateVirtualMachineCount;
+            int count = 0;
+            if (approximateVirtualMachineCountsByTemplate != null) {
+                for (final Integer templateCount : approximateVirtualMachineCountsByTemplate.values()) {
+                    count += templateCount.intValue();
+                }
+            }
+            return count;
         }
     }
 
     /**
-     * Given the number of VMs that are desired, returns the number of VMs that
-     * can be allocated and adjusts the number of VMs we believe exist.
-     * If the number desired is less than 0, this subtracts from the total number
-     * of virtual machines we currently have available.
+     * Retrieves the current count of the number of virtual machines for a specific
+     * template.
      *
-     * @param delta Number that are desired, or if less than 0, the number we are 'returning' to the pool
-     * @param templateLimit max agents for the template in use
-     * @return Number that can be allocated, up to the number desired.  0 if the number desired was < 0
+     * @param templateName The name of the template whose VMs are being counted.
+     * @return The number of VMs of that template.
      */
-    public int adjustVirtualMachineCount(int delta, int templateLimit) {
+    @Restricted(NoExternalUse.class)
+    int getApproximateVirtualMachineCountForTemplate(AzureVMAgentTemplate template) {
+        final String templateName = template.getTemplateName();
         synchronized (this) {
-            if (delta < 0) {
-                LOGGER.log(Level.FINE, "Current estimated VM count: {0}, reducing by {1}",
-                        new Object[]{approximateVirtualMachineCount, delta});
-                approximateVirtualMachineCount = Math.max(0, approximateVirtualMachineCount + delta);
-                return 0;
+            if (approximateVirtualMachineCountsByTemplate != null) {
+                final Integer templateCount = approximateVirtualMachineCountsByTemplate.get(templateName);
+                if (templateCount != null) {
+                    return templateCount.intValue();
+                }
+            }
+            return 0;
+        }
+    }
+
+    /**
+     * Adjusts our estimate of the current number of VMs we have for a specific
+     * template.
+     *
+     * @param delta    The change to make. Positive means we think we've got more
+     *                 VMs, negative means we think we've got fewer.
+     * @param template the template we're talking about.
+     */
+    @Restricted(NoExternalUse.class)
+    void adjustApproximateVirtualMachineCount(int delta, AzureVMAgentTemplate template) {
+        final String templateName = template.getTemplateName();
+        synchronized (this) {
+            final int currentCount = getApproximateVirtualMachineCountForTemplate(template);
+            final int newCount = currentCount + delta;
+            if (approximateVirtualMachineCountsByTemplate == null) {
+                if (newCount != 0) {
+                    setCurrentVirtualMachineCount(Collections.singletonMap(templateName, Integer.valueOf(newCount)));
+                }
             } else {
-                LOGGER.log(Level.FINE, "Current estimated VM count: {0}, quantity desired {1}",
-                        new Object[]{approximateVirtualMachineCount, delta});
-                int limit = determineLimit(templateLimit);
-                if (approximateVirtualMachineCount + delta <= limit) {
-                    // Enough available, return the desired quantity, and update the number we think we
-                    // have laying around.
-                    approximateVirtualMachineCount += delta;
-                    return delta;
+                if (newCount == 0) {
+                    approximateVirtualMachineCountsByTemplate.remove(templateName);
+                    if (approximateVirtualMachineCountsByTemplate.isEmpty()) {
+                        approximateVirtualMachineCountsByTemplate = null;
+                    }
                 } else {
-                    // Not enough available, return what we have. Remember we could
-                    // go negative (if for instance another Jenkins instance had
-                    // a higher limit.
-                    int quantityAvailable = Math.max(0, limit - approximateVirtualMachineCount);
-                    approximateVirtualMachineCount += quantityAvailable;
-                    return quantityAvailable;
+                    approximateVirtualMachineCountsByTemplate.put(templateName, Integer.valueOf(newCount));
                 }
             }
         }
     }
 
-    private int determineLimit(int templateLimit) {
-        int cloudLimit = getMaxVirtualMachinesLimit();
-        if (templateLimit > cloudLimit) {
-            return cloudLimit;
-        }
-        if (templateLimit == 0) {
-            return cloudLimit;
-        }
-        return templateLimit;
-    }
-
     /**
-     * Sets the new approximate virtual machine count.
+     * Sets the new approximate virtual machine counts.
      * This is run by the verification task to update the VM count periodically.
      *
-     * @param newCount New approximate count
+     * @param countsIndexedByTemplateName New approximate counts
      */
-    public void setVirtualMachineCount(int newCount) {
+    @Restricted(NoExternalUse.class)
+    void setCurrentVirtualMachineCount(Map<String, Integer> countsIndexedByTemplateName) {
         synchronized (this) {
-            approximateVirtualMachineCount = newCount;
+            if (countsIndexedByTemplateName == null || countsIndexedByTemplateName.isEmpty()) {
+                approximateVirtualMachineCountsByTemplate = null;
+            } else {
+                if (approximateVirtualMachineCountsByTemplate == null) {
+                    approximateVirtualMachineCountsByTemplate = new TreeMap<>(countsIndexedByTemplateName);
+                } else {
+                    approximateVirtualMachineCountsByTemplate.clear();
+                    approximateVirtualMachineCountsByTemplate.putAll(countsIndexedByTemplateName);
+                }
+            }
         }
     }
 
@@ -675,26 +700,22 @@ public class AzureVMCloud extends Cloud {
         if (numberOfAgents > 0) {
             if (template.getMaximumDeploymentSize() > 0 && numberOfAgents > template.getMaximumDeploymentSize()) {
                 LOGGER.log(Level.FINE,
-                    "Setting size of deployment from {0} to {1} nodes, according to template's maximum deployment size",
-                    new Object[]{numberOfAgents, template.getMaximumDeploymentSize()});
+                        "Reduced template {0} deployment from {1} to {2} nodes, due to its maximumDeploymentSize",
+                        new Object[] {template.getTemplateName(), numberOfAgents,
+                                template.getMaximumDeploymentSize() });
                 numberOfAgents = template.getMaximumDeploymentSize();
             }
 
             try {
                 // Determine how many agents we can actually provision from here and
                 // adjust our count (before deployment to avoid races)
-                int adjustedNumberOfAgents = adjustVirtualMachineCount(numberOfAgents,
-                        template.getMaxVirtualMachinesLimit());
+                final int adjustedNumberOfAgents;
+                synchronized (this) {
+                    adjustedNumberOfAgents = calculateNumberOfAgentsToRequest(template, numberOfAgents);
+                    adjustApproximateVirtualMachineCount(adjustedNumberOfAgents, template);
+                }
                 if (adjustedNumberOfAgents == 0) {
-                    LOGGER.log(Level.INFO,
-                            "Not able to create {0} nodes, at or above maximum VM count of {1} and already {2} VM(s)",
-                            new Object[]{numberOfAgents, determineLimit(template.getMaxVirtualMachinesLimit()),
-                                getApproximateVirtualMachineCount()});
                     return plannedNodes;
-                } else if (adjustedNumberOfAgents < numberOfAgents) {
-                    LOGGER.log(Level.INFO,
-                            "Able to create new nodes, but can only create {0} (desired {1})",
-                            new Object[]{adjustedNumberOfAgents, numberOfAgents});
                 }
                 doProvision(adjustedNumberOfAgents, plannedNodes, template);
                 // wait for deployment completion and then check for created nodes
@@ -708,6 +729,49 @@ public class AzureVMCloud extends Cloud {
 
         LOGGER.log(Level.INFO, "{0} planned node(s)", plannedNodes.size());
         return plannedNodes;
+    }
+
+    /**
+     * Works out how many VMs our limits allow us to request.
+     *
+     * @param template              The template in question
+     * @param desiredNumberOfAgents The number of VMs we'd like to have if there
+     *                              were no limits.
+     * @return The number we can request before exceeding our cloud and template
+     *         limits.
+     */
+    @Restricted(NoExternalUse.class) // Package access for tests only
+    int calculateNumberOfAgentsToRequest(final AzureVMAgentTemplate template, int desiredNumberOfAgents) {
+        final int currentVMsForTemplate = Math.max(0, getApproximateVirtualMachineCountForTemplate(template));
+        final int maxVMsForTemplate = template.getMaxVirtualMachinesLimit() > 0
+                ? template.getMaxVirtualMachinesLimit()
+                : Integer.MAX_VALUE;
+        final int currentVMsForCloud = Math.max(0, getApproximateVirtualMachineCount());
+        final int maxVMsForCloud = getMaxVirtualMachinesLimit() > 0 ? getMaxVirtualMachinesLimit()
+                : Integer.MAX_VALUE;
+        final int maxBeforeTemplateLimit = Math.max(0, maxVMsForTemplate - currentVMsForTemplate);
+        final int maxBeforeCloudLimit = Math.max(0, maxVMsForCloud - currentVMsForCloud);
+        final int adjustedNumberOfAgents = Math.min(Math.min(maxBeforeTemplateLimit, maxBeforeCloudLimit),
+                desiredNumberOfAgents);
+        final String templateMsg = desiredNumberOfAgents > maxBeforeTemplateLimit
+                ? ", have template limit of {3} but have {4} VMs already so we can have {5} more"
+                : ", currently have {4} VMs of this template";
+        final String cloudMsg = desiredNumberOfAgents > maxBeforeCloudLimit
+                ? ", have cloud limit of {6} but have {7} VMs already so we can only have {8} more"
+                : ", currently have {7} VMs in cloud";
+        final Object[] logParams = new Object[] {template.getTemplateName(), desiredNumberOfAgents,
+                adjustedNumberOfAgents, maxVMsForTemplate, currentVMsForTemplate, maxBeforeTemplateLimit,
+                maxVMsForCloud, currentVMsForCloud, maxBeforeCloudLimit };
+        if (adjustedNumberOfAgents == 0) {
+            LOGGER.log(Level.INFO, "Wanted to create {1} nodes from template {0} but cannot create any"
+                    + templateMsg + cloudMsg, logParams);
+        } else if (adjustedNumberOfAgents < desiredNumberOfAgents) {
+            LOGGER.log(Level.INFO, "Wanted to create {1} nodes from template {0} but can only create {2}"
+                    + templateMsg + cloudMsg, logParams);
+        } else {
+            LOGGER.log(Level.INFO, "Creating {1} nodes from template {0}" + templateMsg + cloudMsg, logParams);
+        }
+        return adjustedNumberOfAgents;
     }
 
     public void doProvision(final int numberOfNewAgents,
@@ -858,8 +922,8 @@ public class AzureVMCloud extends Cloud {
                                     // Do not throw to avoid it being recorded
                                 }
                             }
-                            template.retrieveAzureCloudReference().adjustVirtualMachineCount(-1,
-                                    template.getMaxVirtualMachinesLimit());
+                            template.retrieveAzureCloudReference().adjustApproximateVirtualMachineCount(-1,
+                                    template);
                             // Update the template status given this new issue.
                             template.handleTemplateProvisioningFailure(e.getMessage(), stage);
                         }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -1694,10 +1694,10 @@ public final class AzureVMManagementServiceDelegate {
      * @return Total VM count
      */
     public int getVirtualMachineCount(String cloudName, String resourceGroupName) {
-    	final Map<String, Integer> countsByTemplate = getVirtualMachineCountsByTemplate(cloudName, resourceGroupName);
+        final Map<String, Integer> countsByTemplate = getVirtualMachineCountsByTemplate(cloudName, resourceGroupName);
         int count = 0;
         for (Integer countForTemplate : countsByTemplate.values() ) {
-        	count += countForTemplate.intValue();
+            count += countForTemplate;
         }
         return count;
     }
@@ -1710,25 +1710,25 @@ public final class AzureVMManagementServiceDelegate {
      */
     @Restricted(NoExternalUse.class)
     Map<String, Integer> getVirtualMachineCountsByTemplate(final String cloudName, final String resourceGroupName) {
-    	final Map<String, Integer> result = new TreeMap<>();
+        final Map<String, Integer> result = new TreeMap<>();
         try {
             final PagedIterable<VirtualMachine> vms = azureClient.virtualMachines().listByResourceGroup(resourceGroupName);
             final AzureUtil.DeploymentTag deployTag = new AzureUtil.DeploymentTag();
             for (final VirtualMachine vm : vms) {
                 final Map<String, String> tags = vm.tags();
-                final String resourcesTag = tags.containsKey(Constants.AZURE_RESOURCES_TAG_NAME) ? tags.get(Constants.AZURE_RESOURCES_TAG_NAME) : null;
-                final String cloudTag = tags.containsKey(Constants.AZURE_CLOUD_TAG_NAME) ? tags.get(Constants.AZURE_CLOUD_TAG_NAME) : null;
-                final String templateTag = tags.containsKey(Constants.AZURE_TEMPLATE_TAG_NAME) ? tags.get(Constants.AZURE_TEMPLATE_TAG_NAME) : null;
+                final String resourcesTag = tags.getOrDefault(Constants.AZURE_RESOURCES_TAG_NAME, null);
+                final String cloudTag = tags.getOrDefault(Constants.AZURE_CLOUD_TAG_NAME, null);
+                final String templateTag = tags.getOrDefault(Constants.AZURE_TEMPLATE_TAG_NAME, null);
                 if (resourcesTag == null || cloudTag == null || !deployTag.isFromSameInstance(new AzureUtil.DeploymentTag(resourcesTag))) {
-                	continue; // not a VM we created so don't count it
+                    continue; // not a VM we created so don't count it
                 }
                 final String templateThisVmBelongsTo;
                 if (!cloudTag.equals(cloudName)) {
-                	continue; // not a VM from the cloud we're counting
+                    continue; // not a VM from the cloud we're counting
                 }
                 templateThisVmBelongsTo = (templateTag == null) ? "" : templateTag;
                 final Integer existingCountForThisTemplate = result.get(templateThisVmBelongsTo);
-                final Integer newCountForThisTemplate = Integer.valueOf(existingCountForThisTemplate == null ? 1 : (existingCountForThisTemplate.intValue() + 1));
+                final Integer newCountForThisTemplate = existingCountForThisTemplate == null ? 1 : (existingCountForThisTemplate + 1);
                 result.put(templateThisVmBelongsTo, newCountForThisTemplate);
             }
         } catch (ManagementException e) {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -67,6 +67,8 @@ import jenkins.slaves.JnlpAgentReceiver;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -1692,36 +1694,54 @@ public final class AzureVMManagementServiceDelegate {
      * @return Total VM count
      */
     public int getVirtualMachineCount(String cloudName, String resourceGroupName) {
+    	final Map<String, Integer> countsByTemplate = getVirtualMachineCountsByTemplate(cloudName, resourceGroupName);
+        int count = 0;
+        for (Integer countForTemplate : countsByTemplate.values() ) {
+        	count += countForTemplate.intValue();
+        }
+        return count;
+    }
+
+    /**
+     * Retrieves count of virtual machine in a azure subscription indexed by template name.
+     *
+     * @return {@link Map} of {@link String} template name to {@link Integer} count of VMs from that template.
+     * @throws ManagementException if we get an Azure error that isn't 404.
+     */
+    @Restricted(NoExternalUse.class)
+    Map<String, Integer> getVirtualMachineCountsByTemplate(final String cloudName, final String resourceGroupName) {
+    	final Map<String, Integer> result = new TreeMap<>();
         try {
             final PagedIterable<VirtualMachine> vms = azureClient.virtualMachines().listByResourceGroup(resourceGroupName);
-            int count = 0;
             final AzureUtil.DeploymentTag deployTag = new AzureUtil.DeploymentTag();
-            for (VirtualMachine vm : vms) {
+            for (final VirtualMachine vm : vms) {
                 final Map<String, String> tags = vm.tags();
-                if (tags.containsKey(Constants.AZURE_RESOURCES_TAG_NAME)
-                    && deployTag.isFromSameInstance(
-                    new AzureUtil.DeploymentTag(tags.get(Constants.AZURE_RESOURCES_TAG_NAME)))) {
-                    if (tags.containsKey(Constants.AZURE_CLOUD_TAG_NAME)) {
-                        if (tags.get(Constants.AZURE_CLOUD_TAG_NAME).equals(cloudName)) {
-                            count++;
-                        }
-                    } else {
-                        // keep backwards compatibility, omitting the resource created before updates
-                        // until all the resources has cloud tag
-                        count++;
-                    }
+                final String resourcesTag = tags.containsKey(Constants.AZURE_RESOURCES_TAG_NAME) ? tags.get(Constants.AZURE_RESOURCES_TAG_NAME) : null;
+                final String cloudTag = tags.containsKey(Constants.AZURE_CLOUD_TAG_NAME) ? tags.get(Constants.AZURE_CLOUD_TAG_NAME) : null;
+                final String templateTag = tags.containsKey(Constants.AZURE_TEMPLATE_TAG_NAME) ? tags.get(Constants.AZURE_TEMPLATE_TAG_NAME) : null;
+                if (resourcesTag == null || cloudTag == null || !deployTag.isFromSameInstance(new AzureUtil.DeploymentTag(resourcesTag))) {
+                	continue; // not a VM we created so don't count it
                 }
+                final String templateThisVmBelongsTo;
+                if (!cloudTag.equals(cloudName)) {
+                	continue; // not a VM from the cloud we're counting
+                }
+                templateThisVmBelongsTo = (templateTag == null) ? "" : templateTag;
+                final Integer existingCountForThisTemplate = result.get(templateThisVmBelongsTo);
+                final Integer newCountForThisTemplate = Integer.valueOf(existingCountForThisTemplate == null ? 1 : (existingCountForThisTemplate.intValue() + 1));
+                result.put(templateThisVmBelongsTo, newCountForThisTemplate);
             }
-            return count;
         } catch (ManagementException e) {
             if (e.getResponse().getStatusCode() != 404) {
                 throw e;
             }
-            return 0;
+            LOGGER.log(Level.SEVERE, "Failed to retrieve count of virtual machines from cloud '" + cloudName + "' resourceGroup '" + resourceGroupName + "'.", e);
+            return Collections.emptyMap();
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Failed to retrieve count of virtual machines", e);
-            return 0;
+            LOGGER.log(Level.SEVERE, "Failed to retrieve count of virtual machines from cloud '" + cloudName + "' resourceGroup '" + resourceGroupName + "'.", e);
+            return Collections.emptyMap();
         }
+        return result;
     }
 
     /**

--- a/src/test/java/com/microsoft/azure/vmagent/AzureClientUtil.java
+++ b/src/test/java/com/microsoft/azure/vmagent/AzureClientUtil.java
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-package com.microsoft.azure.vmagent.test;
+package com.microsoft.azure.vmagent;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.management.profile.AzureProfile;

--- a/src/test/java/com/microsoft/azure/vmagent/AzureVMCloudTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/AzureVMCloudTest.java
@@ -57,7 +57,7 @@ public class AzureVMCloudTest {
         final String templateName = "myTemplate";
         final AzureVMAgentTemplate template = mkTemplate(templateName);
         final int templateCount = 123;
-        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, Integer.valueOf(templateCount));
+        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, templateCount);
         final int expectedCloud = templateCount;
         final int expectedTemplate = templateCount;
 
@@ -77,9 +77,9 @@ public class AzureVMCloudTest {
         final AzureVMCloud instance = mkInstance();
         final String templateName = "myTemplate";
         final AzureVMAgentTemplate template = mkTemplate(templateName);
-        instance.setCurrentVirtualMachineCount(Collections.singletonMap("foo", Integer.valueOf(234)));
+        instance.setCurrentVirtualMachineCount(Collections.singletonMap("foo", 234));
         final int templateCount = 123;
-        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, Integer.valueOf(templateCount));
+        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, templateCount);
         final int expectedCloud = templateCount;
         final int expectedTemplate = templateCount;
 
@@ -100,7 +100,7 @@ public class AzureVMCloudTest {
         final String templateName = "myTemplate";
         final AzureVMAgentTemplate template = mkTemplate(templateName);
         final int templateCount = 123;
-        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, Integer.valueOf(templateCount));
+        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, templateCount);
         final int expectedCloud = 0;
         final int expectedTemplate = 0;
         instance.setCurrentVirtualMachineCount(vmCount);
@@ -122,7 +122,7 @@ public class AzureVMCloudTest {
         final String templateName = "myTemplate";
         final AzureVMAgentTemplate template = mkTemplate(templateName);
         final int templateCount = 123;
-        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, Integer.valueOf(templateCount));
+        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, templateCount);
         final int expectedCloud = templateCount + 2;
         final int expectedTemplate = templateCount + 2;
         instance.setCurrentVirtualMachineCount(vmCount);

--- a/src/test/java/com/microsoft/azure/vmagent/AzureVMCloudTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/AzureVMCloudTest.java
@@ -1,0 +1,295 @@
+package com.microsoft.azure.vmagent;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class AzureVMCloudTest {
+
+    @Test
+    public void setCurrentVirtualMachineCountGivenNullThenSetsNull() {
+        // Given
+        final AzureVMCloud instance = mkInstance();
+        final String templateName = "myTemplate";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final Map<String, Integer> vmCount = null;
+        final int expectedCloud = 0;
+        final int expectedTemplate = 0;
+
+        // When
+        instance.setCurrentVirtualMachineCount(vmCount);
+
+        // Then
+        final int actualCloud = instance.getApproximateVirtualMachineCount();
+        assertThat(actualCloud, equalTo(expectedCloud));
+        final int actualTemplate = instance.getApproximateVirtualMachineCountForTemplate(template);
+        assertThat(actualTemplate, equalTo(expectedTemplate));
+    }
+
+    @Test
+    public void setCurrentVirtualMachineCountGivenEmptyThenSetsNull() {
+        // Given
+        final AzureVMCloud instance = mkInstance();
+        final String templateName = "myTemplate";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final Map<String, Integer> vmCount = Collections.emptyMap();
+        final int expectedCloud = 0;
+        final int expectedTemplate = 0;
+
+        // When
+        instance.setCurrentVirtualMachineCount(vmCount);
+
+        // Then
+        final int actualCloud = instance.getApproximateVirtualMachineCount();
+        assertThat(actualCloud, equalTo(expectedCloud));
+        final int actualTemplate = instance.getApproximateVirtualMachineCountForTemplate(template);
+        assertThat(actualTemplate, equalTo(expectedTemplate));
+    }
+
+    @Test
+    public void setCurrentVirtualMachineCountGivenOneTemplateThenRecordsCount() {
+        // Given
+        final AzureVMCloud instance = mkInstance();
+        final String templateName = "myTemplate";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final int templateCount = 123;
+        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, Integer.valueOf(templateCount));
+        final int expectedCloud = templateCount;
+        final int expectedTemplate = templateCount;
+
+        // When
+        instance.setCurrentVirtualMachineCount(vmCount);
+
+        // Then
+        final int actualCloud = instance.getApproximateVirtualMachineCount();
+        assertThat(actualCloud, equalTo(expectedCloud));
+        final int actualTemplate = instance.getApproximateVirtualMachineCountForTemplate(template);
+        assertThat(actualTemplate, equalTo(expectedTemplate));
+    }
+
+    @Test
+    public void setCurrentVirtualMachineCountGivenNewValuesThenReplacesValues() {
+        // Given
+        final AzureVMCloud instance = mkInstance();
+        final String templateName = "myTemplate";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        instance.setCurrentVirtualMachineCount(Collections.singletonMap("foo", Integer.valueOf(234)));
+        final int templateCount = 123;
+        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, Integer.valueOf(templateCount));
+        final int expectedCloud = templateCount;
+        final int expectedTemplate = templateCount;
+
+        // When
+        instance.setCurrentVirtualMachineCount(vmCount);
+
+        // Then
+        final int actualCloud = instance.getApproximateVirtualMachineCount();
+        assertThat(actualCloud, equalTo(expectedCloud));
+        final int actualTemplate = instance.getApproximateVirtualMachineCountForTemplate(template);
+        assertThat(actualTemplate, equalTo(expectedTemplate));
+    }
+
+    @Test
+    public void adjustApproximateVirtualMachineCountGivenNegativeAdjustmentThenAdjustsDown() {
+        // Given
+        final AzureVMCloud instance = mkInstance();
+        final String templateName = "myTemplate";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final int templateCount = 123;
+        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, Integer.valueOf(templateCount));
+        final int expectedCloud = 0;
+        final int expectedTemplate = 0;
+        instance.setCurrentVirtualMachineCount(vmCount);
+
+        // When
+        instance.adjustApproximateVirtualMachineCount(-templateCount, template);
+
+        // Then
+        final int actualCloud = instance.getApproximateVirtualMachineCount();
+        assertThat(actualCloud, equalTo(expectedCloud));
+        final int actualTemplate = instance.getApproximateVirtualMachineCountForTemplate(template);
+        assertThat(actualTemplate, equalTo(expectedTemplate));
+    }
+
+    @Test
+    public void adjustApproximateVirtualMachineCountGivenPositiveAdjustmentThenAdjustsUp() {
+        // Given
+        final AzureVMCloud instance = mkInstance();
+        final String templateName = "myTemplate";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final int templateCount = 123;
+        final Map<String, Integer> vmCount = Collections.singletonMap(templateName, Integer.valueOf(templateCount));
+        final int expectedCloud = templateCount + 2;
+        final int expectedTemplate = templateCount + 2;
+        instance.setCurrentVirtualMachineCount(vmCount);
+
+        // When
+        instance.adjustApproximateVirtualMachineCount(2, template);
+
+        // Then
+        final int actualCloud = instance.getApproximateVirtualMachineCount();
+        assertThat(actualCloud, equalTo(expectedCloud));
+        final int actualTemplate = instance.getApproximateVirtualMachineCountForTemplate(template);
+        assertThat(actualTemplate, equalTo(expectedTemplate));
+    }
+
+    @Test
+    public void adjustApproximateVirtualMachineCountGivenComplexScenarioThenKeepsTrack() {
+        // Given
+        final AzureVMCloud instance = mkInstance();
+        final String template1Name = "myTemplate";
+        final AzureVMAgentTemplate template1 = mkTemplate(template1Name);
+        final String template2Name = "Template2";
+        final AzureVMAgentTemplate template2 = mkTemplate(template2Name);
+        final String template3Name = "Template3";
+        final AzureVMAgentTemplate template3 = mkTemplate(template3Name);
+        final int expectedTemplate1 = 1;
+        final int expectedTemplate2 = 2;
+        final int expectedTemplate3 = 3;
+        final int expectedCloud = expectedTemplate1 + expectedTemplate2 + expectedTemplate3;
+
+        // When
+        instance.adjustApproximateVirtualMachineCount(0, template1);
+        instance.adjustApproximateVirtualMachineCount(1, template1);
+        instance.adjustApproximateVirtualMachineCount(10, template2);
+        instance.adjustApproximateVirtualMachineCount(100, template3);
+        instance.adjustApproximateVirtualMachineCount(1, template1);
+        instance.adjustApproximateVirtualMachineCount(-10, template2);
+        instance.adjustApproximateVirtualMachineCount(100, template3);
+        instance.adjustApproximateVirtualMachineCount(-197, template3);
+        instance.adjustApproximateVirtualMachineCount(2, template2);
+        instance.adjustApproximateVirtualMachineCount(-1, template1);
+
+        // Then
+        final int actualCloud = instance.getApproximateVirtualMachineCount();
+        assertThat(actualCloud, equalTo(expectedCloud));
+        final int actualTemplate1 = instance.getApproximateVirtualMachineCountForTemplate(template1);
+        assertThat(actualTemplate1, equalTo(expectedTemplate1));
+        final int actualTemplate2 = instance.getApproximateVirtualMachineCountForTemplate(template2);
+        assertThat(actualTemplate2, equalTo(expectedTemplate2));
+        final int actualTemplate3 = instance.getApproximateVirtualMachineCountForTemplate(template3);
+        assertThat(actualTemplate3, equalTo(expectedTemplate3));
+    }
+
+    @Test
+    public void calculateNumberOfAgentsToRequestGivenNoLimitsThenReturnsUnchangedCount() {
+        // Given
+        final String templateName = "templateName";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final AzureVMCloud instance = mkInstance();
+        final int numberRequested = 99;
+        final int expected = numberRequested;
+
+        // When
+        int actual = instance.calculateNumberOfAgentsToRequest(template, numberRequested);
+
+        // Then
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void calculateNumberOfAgentsToRequestGivenHighLimitsThenReturnsUnchangedCount() {
+        // Given
+        final String templateName = "templateName";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final AzureVMCloud instance = mkInstance(321);
+        template.setMaxVirtualMachinesLimit(123);
+        final int numberRequested = 99;
+        final int expected = numberRequested;
+
+        // When
+        int actual = instance.calculateNumberOfAgentsToRequest(template, numberRequested);
+
+        // Then
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void calculateNumberOfAgentsToRequestGivenTemplateLimitThenReturnsTemplateRemainder() {
+        // Given
+        final String templateName = "templateName";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final AzureVMCloud instance = mkInstance();
+        template.setMaxVirtualMachinesLimit(123);
+        instance.adjustApproximateVirtualMachineCount(100, template);
+        final int numberRequested = 99;
+        final int expected = 23;
+
+        // When
+        int actual = instance.calculateNumberOfAgentsToRequest(template, numberRequested);
+
+        // Then
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void calculateNumberOfAgentsToRequestGivenCloudLimitThenReturnsCloudRemainder() {
+        // Given
+        final String templateName = "templateName";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final AzureVMCloud instance = mkInstance(321);
+        instance.adjustApproximateVirtualMachineCount(300, mkTemplate("otherTemplate"));
+        final int numberRequested = 99;
+        final int expected = 21;
+
+        // When
+        int actual = instance.calculateNumberOfAgentsToRequest(template, numberRequested);
+
+        // Then
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void calculateNumberOfAgentsToRequestGivenBothCloudAndTemplateLimitThenReturnsLowerRemainder() {
+        // Given
+        final String templateName = "templateName";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final AzureVMCloud instance = mkInstance(321);
+        instance.adjustApproximateVirtualMachineCount(200, mkTemplate("otherTemplate"));
+        template.setMaxVirtualMachinesLimit(123);
+        instance.adjustApproximateVirtualMachineCount(100, template);
+        final int numberRequested = 99;
+        final int expected = 21;
+
+        // When
+        int actual = instance.calculateNumberOfAgentsToRequest(template, numberRequested);
+
+        // Then
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void calculateNumberOfAgentsToRequestGivenTooLowLimitThenReturnsZero() {
+        // Given
+        final String templateName = "templateName";
+        final AzureVMAgentTemplate template = mkTemplate(templateName);
+        final AzureVMCloud instance = mkInstance(100);
+        instance.adjustApproximateVirtualMachineCount(100, template);
+        template.setMaxVirtualMachinesLimit(100);
+        final int numberRequested = 99;
+        final int expected = 0;
+
+        // When
+        int actual = instance.calculateNumberOfAgentsToRequest(template, numberRequested);
+
+        // Then
+        assertThat(actual, equalTo(expected));
+    }
+
+    private static AzureVMAgentTemplate mkTemplate(final String templateName) {
+        return new AzureVMAgentTemplate(templateName, null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, false, false);
+    }
+
+    private static AzureVMCloud mkInstance(int maxVMsLimitForCloud) {
+        return new AzureVMCloud(null, null, Integer.toString(maxVMsLimitForCloud), null, null, null, null, null);
+    }
+
+    private static AzureVMCloud mkInstance() {
+        return mkInstance(0);
+    }
+}

--- a/src/test/java/com/microsoft/azure/vmagent/ITAzureVMAgentCleanUpTask.java
+++ b/src/test/java/com/microsoft/azure/vmagent/ITAzureVMAgentCleanUpTask.java
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-package com.microsoft.azure.vmagent.test;
+package com.microsoft.azure.vmagent;
 
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.resources.models.GenericResource;
-import com.microsoft.azure.vmagent.AzureVMAgentCleanUpTask;
-import com.microsoft.azure.vmagent.AzureVMAgentCleanUpTask.DeploymentRegistrar;
-import com.microsoft.azure.vmagent.AzureVMCloud;
-import com.microsoft.azure.vmagent.AzureVMDeploymentInfo;
 import com.microsoft.azure.vmagent.util.AzureUtil;
 import com.microsoft.azure.vmagent.util.Constants;
 import hudson.model.TaskListener;
@@ -48,7 +44,7 @@ public class ITAzureVMAgentCleanUpTask extends IntegrationTest {
     public void cleanDeploymentsTest() throws Exception {
         final AzureVMDeploymentInfo deploymentInfo = createDefaultDeployment(1, null);
         final String cloudName = "fake_cloud_name";
-        final DeploymentRegistrar deploymentRegistrar = DeploymentRegistrar.getInstance();
+        final AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrar = AzureVMAgentCleanUpTask.DeploymentRegistrar.getInstance();
 
         deploymentRegistrar.registerDeployment(cloudName, testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null);
         AzureVMAgentCleanUpTask cleanUpMock = spy(AzureVMAgentCleanUpTask.class);
@@ -86,11 +82,11 @@ public class ITAzureVMAgentCleanUpTask extends IntegrationTest {
         AzureVMAgentCleanUpTask cleanUpTask = spy(AzureVMAgentCleanUpTask.class);
         when(cleanUpTask.getValidVMs()).thenReturn(emptyValidVMsList);
 
-        final DeploymentRegistrar deploymentRegistrarMock_nonMatching1 = mock(DeploymentRegistrar.class);
+        final AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrarMock_nonMatching1 = mock(AzureVMAgentCleanUpTask.DeploymentRegistrar.class);
         when(deploymentRegistrarMock_nonMatching1.getDeploymentTag()).thenReturn(nonMatchingTagValue1);
-        final DeploymentRegistrar deploymentRegistrarMock_nonMatching2 = mock(DeploymentRegistrar.class);
+        final AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrarMock_nonMatching2 = mock(AzureVMAgentCleanUpTask.DeploymentRegistrar.class);
         when(deploymentRegistrarMock_nonMatching2.getDeploymentTag()).thenReturn(nonMatchingTagValue2);
-        final DeploymentRegistrar deploymentRegistrarMock_matching = mock(DeploymentRegistrar.class);
+        final AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrarMock_matching = mock(AzureVMAgentCleanUpTask.DeploymentRegistrar.class);
         when(deploymentRegistrarMock_matching.getDeploymentTag()).thenReturn(matchingTagValue);
 
         createAzureVM(vmName, tagName, tagValue.get());
@@ -118,9 +114,9 @@ public class ITAzureVMAgentCleanUpTask extends IntegrationTest {
         when(cloud.getAzureClient()).thenReturn(azureClient);
         when(cloud.getServiceDelegate()).thenReturn(delegate);
 
-        final DeploymentRegistrar deploymentRegistrarMock = mock(DeploymentRegistrar.class);
+        final AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrarMock = mock(AzureVMAgentCleanUpTask.DeploymentRegistrar.class);
         when(deploymentRegistrarMock.getDeploymentTag()).thenReturn(tagValue);
-        final DeploymentRegistrar deploymentRegistrarMock_matching = mock(DeploymentRegistrar.class);
+        final AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrarMock_matching = mock(AzureVMAgentCleanUpTask.DeploymentRegistrar.class);
         when(deploymentRegistrarMock_matching.getDeploymentTag()).thenReturn(matchingTagValue);
 
         final AzureVMDeploymentInfo deployment = createDefaultDeployment(2, deploymentRegistrarMock);

--- a/src/test/java/com/microsoft/azure/vmagent/ITAzureVMCloud.java
+++ b/src/test/java/com/microsoft/azure/vmagent/ITAzureVMCloud.java
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-package com.microsoft.azure.vmagent.test;
+package com.microsoft.azure.vmagent;
 
-import com.microsoft.azure.vmagent.AzureVMAgent;
-import com.microsoft.azure.vmagent.AzureVMAgentTemplate;
-import com.microsoft.azure.vmagent.AzureVMCloud;
-import com.microsoft.azure.vmagent.AzureVMDeploymentInfo;
 import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
 import com.microsoft.azure.vmagent.util.Constants;
 import hudson.model.Node;

--- a/src/test/java/com/microsoft/azure/vmagent/ITAzureVMManagementServiceDelegate.java
+++ b/src/test/java/com/microsoft/azure/vmagent/ITAzureVMManagementServiceDelegate.java
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-package com.microsoft.azure.vmagent.test;
+package com.microsoft.azure.vmagent;
 
 import com.azure.core.management.exception.ManagementException;
 import com.azure.resourcemanager.compute.models.AvailabilitySet;
@@ -27,14 +27,6 @@ import com.azure.resourcemanager.network.models.PublicIpAddress;
 import com.azure.resourcemanager.storage.models.SkuName;
 import com.azure.resourcemanager.storage.models.StorageAccount;
 import com.azure.resourcemanager.storage.models.StorageAccountSkuType;
-import com.microsoft.azure.vmagent.AvailabilityType;
-import com.microsoft.azure.vmagent.AzureVMAgent;
-import com.microsoft.azure.vmagent.AzureVMAgentCleanUpTask;
-import com.microsoft.azure.vmagent.AzureVMAgentTemplate;
-import com.microsoft.azure.vmagent.AzureVMCloud;
-import com.microsoft.azure.vmagent.AzureVMDeploymentInfo;
-import com.microsoft.azure.vmagent.AzureVMManagementServiceDelegate;
-import com.microsoft.azure.vmagent.Messages;
 import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
 import com.microsoft.azure.vmagent.retry.RetryStrategy;
 import com.microsoft.azure.vmagent.util.AzureUtil;

--- a/src/test/java/com/microsoft/azure/vmagent/IntegrationTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/IntegrationTest.java
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-package com.microsoft.azure.vmagent.test;
+package com.microsoft.azure.vmagent;
 
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.management.exception.ManagementException;
@@ -39,13 +39,6 @@ import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.microsoft.azure.util.AzureCredentials;
-import com.microsoft.azure.vmagent.AvailabilityType;
-import com.microsoft.azure.vmagent.AzureTagPair;
-import com.microsoft.azure.vmagent.AzureVMAgentCleanUpTask;
-import com.microsoft.azure.vmagent.AzureVMAgentTemplate;
-import com.microsoft.azure.vmagent.AzureVMCloud;
-import com.microsoft.azure.vmagent.AzureVMDeploymentInfo;
-import com.microsoft.azure.vmagent.AzureVMManagementServiceDelegate;
 import com.microsoft.azure.vmagent.exceptions.AzureCloudException;
 import com.microsoft.azure.vmagent.util.Constants;
 import hudson.util.Secret;

--- a/src/test/java/com/microsoft/azure/vmagent/IntegrationTest.java
+++ b/src/test/java/com/microsoft/azure/vmagent/IntegrationTest.java
@@ -319,11 +319,28 @@ public class IntegrationTest {
     }
 
     protected AzureVMDeploymentInfo createDefaultDeployment(
+            String templateName,
+            int numberOfAgents,
+            AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrar
+    ) throws AzureCloudException, IOException, Exception {
+        return createDefaultDeployment(templateName, numberOfAgents, true, deploymentRegistrar);
+    }
+
+    protected AzureVMDeploymentInfo createDefaultDeployment(
             int numberOfAgents,
             boolean usePrivateIP,
             AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrar
     ) throws AzureCloudException, IOException, Exception {
         return createDefaultDeployment(numberOfAgents, usePrivateIP, false, false, false, "", deploymentRegistrar);
+    }
+
+    protected AzureVMDeploymentInfo createDefaultDeployment(
+            String templateName,
+            int numberOfAgents,
+            boolean usePrivateIP,
+            AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrar
+    ) throws AzureCloudException, IOException, Exception {
+        return createDefaultDeployment(templateName, numberOfAgents, usePrivateIP, false, false, false, "", deploymentRegistrar);
     }
 
     protected AzureVMDeploymentInfo createDefaultDeployment(
@@ -344,6 +361,19 @@ public class IntegrationTest {
             AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrar
     ) throws Exception {
         final String templateName = "t" + TestEnvironment.GenerateRandomString(7);
+        return createDefaultDeployment(templateName, numberOfAgents, usePrivateIP, enableMSI, enableUAMI, ephemeralOSDisk, nsgName, deploymentRegistrar);
+    }
+
+    protected AzureVMDeploymentInfo createDefaultDeployment(
+            String templateName,
+            int numberOfAgents,
+            boolean usePrivateIP,
+            boolean enableMSI,
+            boolean enableUAMI,
+            boolean ephemeralOSDisk,
+            String nsgName,
+            AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrar
+    ) throws Exception {
         final String osType = OS_TYPE;
         final String initScript = "echo \"" + UUID.randomUUID().toString() + "\"";
         final String terminateScript = "echo \"" + UUID.randomUUID().toString() + "\"";

--- a/src/test/java/com/microsoft/azure/vmagent/TestDeploymentTag.java
+++ b/src/test/java/com/microsoft/azure/vmagent/TestDeploymentTag.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.microsoft.azure.vmagent.test;
+package com.microsoft.azure.vmagent;
 
 import com.microsoft.azure.vmagent.util.AzureUtil;
 import org.junit.Assert;


### PR DESCRIPTION
Fix #344

Implemented changes as per [my comment](https://github.com/jenkinsci/azure-vm-agents-plugin/issues/344#issuecomment-1158773947)

Added some basic unit-tests to verify the logic.

...but not tested it "for real" yet, so don't merge it yet!