### PR TITLE
Remove NIC and IP address on deletion using Azure built-in functionality

### DIFF
--- a/src/main/resources/customImageTemplate.json
+++ b/src/main/resources/customImageTemplate.json
@@ -19,7 +19,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
             "location": "[variables('location')]",

--- a/src/main/resources/customImageTemplateWithManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithManagedDisk.json
@@ -40,7 +40,7 @@
             }
         },
         {
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
             "location": "[variables('location')]",
@@ -68,7 +68,7 @@
             }
         },
         {
-            "apiVersion": "2020-06-01",
+            "apiVersion": "2022-11-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -105,7 +105,10 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]",
+                            "properties": {
+                                "deleteOption": "Delete"
+                            }
                         }
                     ]
                 }

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -27,7 +27,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
             "location": "[variables('location')]",
@@ -55,7 +55,7 @@
             }
         },
         {
-            "apiVersion": "2020-06-01",
+            "apiVersion": "2022-11-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -93,7 +93,10 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]",
+                            "properties": {
+                                "deleteOption": "Delete"
+                            }
                         }
                     ]
                 }

--- a/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
@@ -48,7 +48,7 @@
             }
         },
         {
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
             "location": "[variables('location')]",
@@ -76,7 +76,7 @@
             }
         },
         {
-            "apiVersion": "2020-06-01",
+            "apiVersion": "2022-11-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -113,7 +113,10 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]",
+                            "properties": {
+                                "deleteOption": "Delete"
+                            }
                         }
                     ]
                 }

--- a/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
@@ -20,7 +20,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
             "location": "[variables('location')]",
@@ -48,7 +48,7 @@
             }
         },
         {
-            "apiVersion": "2020-06-01",
+            "apiVersion": "2022-11-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -84,7 +84,10 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]",
+                            "properties": {
+                                "deleteOption": "Delete"
+                            }
                         }
                     ]
                 }

--- a/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
@@ -28,7 +28,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
             "location": "[variables('location')]",
@@ -56,7 +56,7 @@
             }
         },
         {
-            "apiVersion": "2020-06-01",
+            "apiVersion": "2022-11-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -92,7 +92,10 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]",
+                            "properties": {
+                                "deleteOption": "Delete"
+                            }
                         }
                     ]
                 }

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -20,7 +20,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
             "location": "[variables('location')]",
@@ -48,7 +48,7 @@
             }
         },
         {
-            "apiVersion": "2020-06-01",
+            "apiVersion": "2022-11-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -88,7 +88,10 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]",
+                            "properties": {
+                                "deleteOption": "Delete"
+                            }
                         }
                     ]
                 }

--- a/src/main/resources/referenceImageTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithManagedDisk.json
@@ -20,7 +20,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
             "location": "[variables('location')]",
@@ -48,7 +48,7 @@
             }
         },
         {
-            "apiVersion": "2020-06-01",
+            "apiVersion": "2022-11-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -87,7 +87,10 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]",
+                            "properties": {
+                                "deleteOption": "Delete"
+                            }
                         }
                     ]
                 }

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -28,7 +28,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
             "location": "[variables('location')]",
@@ -56,7 +56,7 @@
             }
         },
         {
-            "apiVersion": "2020-06-01",
+            "apiVersion": "2022-11-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -96,7 +96,10 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]",
+                            "properties": {
+                                "deleteOption": "Delete"
+                            }
                         }
                     ]
                 }

--- a/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
@@ -28,7 +28,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'), copyIndex(), 'NIC')]",
             "location": "[variables('location')]",
@@ -56,7 +56,7 @@
             }
         },
         {
-            "apiVersion": "2020-06-01",
+            "apiVersion": "2022-11-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyIndex())]",
             "location": "[variables('location')]",
@@ -95,7 +95,10 @@
                 "networkProfile": {
                     "networkInterfaces": [
                         {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]",
+                            "properties": {
+                                "deleteOption": "Delete"
+                            }
                         }
                     ]
                 }

--- a/src/test/java/com/microsoft/azure/vmagent/ITAzureVMManagementServiceDelegate.java
+++ b/src/test/java/com/microsoft/azure/vmagent/ITAzureVMManagementServiceDelegate.java
@@ -748,47 +748,6 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
     }
 
     @Test
-    public void removeIPNameTest() {
-        try {
-            final AzureVMDeploymentInfo deploymentInfo = createDefaultDeployment(1, null);
-            final String nodeName = deploymentInfo.getVmBaseName() + "0";
-
-            delegate.removeIPName(testEnv.azureResourceGroup, nodeName, false);
-            //should fail because the VM is still using them
-            Assert.assertNotNull(
-                    azureClient
-                            .publicIpAddresses()
-                            .getByResourceGroup(testEnv.azureResourceGroup, nodeName + "IPName")
-            );
-            Assert.assertNotNull(
-                    azureClient
-                            .networkInterfaces()
-                            .getByResourceGroup(testEnv.azureResourceGroup, nodeName + "NIC")
-            );
-
-            // destroy the vm first
-            azureClient.virtualMachines().deleteByResourceGroup(testEnv.azureResourceGroup, nodeName);
-            delegate.removeIPName(testEnv.azureResourceGroup, nodeName, false);
-            ManagementException managementException = assertThrows(ManagementException.class, () ->
-                    azureClient
-                            .publicIpAddresses()
-                            .getByResourceGroup(testEnv.azureResourceGroup, nodeName + "IPName")
-            );
-
-            assertThat(managementException.getResponse().getStatusCode(), equalTo(404));
-            managementException = assertThrows(ManagementException.class, () ->
-                    azureClient
-                            .networkInterfaces()
-                            .getByResourceGroup(testEnv.azureResourceGroup, nodeName + "NIC")
-            );
-            assertThat(managementException.getResponse().getStatusCode(), equalTo(404));
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, null, e);
-            Assert.fail(e.getMessage());
-        }
-    }
-
-    @Test
     public void restartVMTest() throws IOException, AzureCloudException {
         final String vmName = "vmrestart";
         VirtualMachine vm = createAzureVM(vmName);


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/401

This required updating the API versions in use for network interfaces and virtual machines.

Tested a simple case in:
<img width="432" alt="image" src="https://user-images.githubusercontent.com/21194782/233322031-1b5ef5dd-9e57-4c1c-8b2f-6b61b7f6bb2e.png">

I deleted the VM and it was removed along with the disk, nic and public ip.

