### PR TITLE
Linux inbound agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Jenkins Plugin to create Jenkins agents in Azure Virtual Machines (via Azure A
 
 Supported features:
 
-1. Windows Agents on Azure Cloud using SSH and JNLP
+1. Windows Agents on Azure Cloud using SSH and Inbound agent connection
    * For Windows images to launch via SSH, the image needs to be preconfigured with SSH.
    * For preparing custom windows image, refer to [Azure documentation](http://azure.microsoft.com/en-us/documentation/articles/virtual-machines-capture-image-windows-server/)
 2. Linux Agents on Azure Cloud using SSH
@@ -88,21 +88,20 @@ The built-in image only has a clean Windows or Ubuntu OS and some tools like Git
    * Use a custom user image (provide image URL and OS type - note, your custom image has to be available into the same storage account in which you are going to create agent nodes);
    * Using any marketplace image by specifying an image reference (provide image reference by publisher, offer, sku and version). You can get the publisher, offer and sku by looking at the ARM template of that image.
 3. For the launch method, select SSH or JNLP.
-   * Linux agents can be launched only using SSH.
-   * Windows agents can be launched using SSH or JNLP. For Windows agents, if the launch method is SSH then check Pre-Install SSH in Windows Agent or image needs to be custom-prepared with an SSH server pre-installed.
+   * For Windows agents, if the launch method is SSH then check Pre-Install SSH in Windows Agent or image needs to be custom-prepared with an SSH server pre-installed.
 
-   We recommend to use SSH rather than JNLP, for you need less init codes and get much clearer logs.
-   > When using the JNLP launch option, ensure the following:
+   We recommend to use SSH rather than connecting it to the controller, it's simpler to setup and get much clearer logs.
+   > When using the Inbound agent launch option, ensure the following:
    > * Jenkins URL (Manage Jenkins -> Configure System -> Jenkins Location)
    > * The URL needs to be reachable by the Azure agent, so make sure to configure any relevant firewall rules accordingly.
-   > * TCP port for JNLP agent agents (Manage Jenkins -> Configure Global Security -> Enable security -> TCP port for JNLP agents).
-   > * The TCP port needs to be reachable from the Azure agent launched using JNLP. It is recommended to use a fixed port so that any necessary firewall exceptions can be made.
+   > * TCP port for Inbound agents (Manage Jenkins -> Configure Global Security -> Enable security -> TCP port for inbound agents).
+   > * The TCP port needs to be reachable from the Azure agent launched with connecting to the controller. It is recommended to use a fixed port so that any necessary firewall exceptions can be made.
    >
-   > If the Jenkins controller is running on Azure, then open an endpoint for "TCP port for JNLP agent agents" and,
+   > If the Jenkins controller is running on Azure, then open an endpoint for "TCP port for Inbound agents" and,
    > in case of Windows, add the necessary firewall rules inside virtual machine (Run -> firewall.cpl).
 
-4. For the Initialization Script, you can provide a script that will be executed after the VM is provisioned. This allows to install any app/tool you need on the agent. Please be noted you need to at least install JRE if the image does not have Java pre-installed.
-   We prepared a sample script for Linux via SSH, Windows via SSH and Windows via JNLP. Please find details in help button.
+4. For the Initialization Script, you can provide a script that will be executed after the VM is provisioned. This allows to install any app/tool you need on the agent. Please be aware you need to at least install JRE if the image does not have Java pre-installed.
+   We prepared a sample script for Linux via SSH, Windows via SSH and Windows via connecting to the controller. Please find details in help button.
 
    If you hit the [storage scalability limits](https://docs.microsoft.com/en-us/azure/storage/storage-scalability-targets) for your custom images on the storage account where the VHD resides, you should consider using the agent's [temporary storage](https://blogs.msdn.microsoft.com/mast/2013/12/06/understanding-the-temporary-drive-on-windows-azure-virtual-machines) or copy your custom image in multiple storage accounts and use multiple VM templates with the same label within the same agent cloud.
 

--- a/docs/init-scripts/linux-inbound-agent.sh
+++ b/docs/init-scripts/linux-inbound-agent.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+JENKINS_URL=$1
+AGENT_NAME=$2
+SECRET=$3
+
+mkdir /opt/jenkins
+
+(
+  cd /opt/jenkins
+  apt-get update
+  apt-get install -y default-jdk git
+
+  MAVEN_VERSION=3.9.1
+  curl -O "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+  tar zxvf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt/
+  ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/bin/mvn
+
+  mvn --version
+
+  curl -O "$JENKINS_URL/jnlpJars/agent.jar"
+
+  java -jar agent.jar -jnlpUrl "$JENKINS_URL/computer/$AGENT_NAME/jenkins-agent.jnlp" -secret "$SECRET" -workDir /opt/jenkins/workDir
+) |& tee /opt/jenkins/init-script.log

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -735,7 +735,9 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
                         AzureVMManagementServiceDelegate.PRE_INSTALLED_TOOLS_SCRIPT
                                 .get(builtInImage).get(Constants.INSTALL_GIT));
             }
-            if ((builtInImage.equals(Constants.UBUNTU_1604_LTS) || builtInImage.equals(Constants.UBUNTU_2004_LTS))
+            if ((builtInImage.equals(Constants.UBUNTU_1604_LTS)
+                   || builtInImage.equals(Constants.UBUNTU_2004_LTS)
+                   || builtInImage.equals(Constants.UBUNTU_2204_LTS))
                     && template.isInstallDocker()) {
                 stringBuilder.append(getSeparator(template.getOsType()));
                 stringBuilder.append(
@@ -1584,6 +1586,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
         public ListBoxModel doFillBuiltInImageItems() {
             ListBoxModel model = new ListBoxModel();
+            model.add(Constants.UBUNTU_2204_LTS);
             model.add(Constants.UBUNTU_2004_LTS);
             model.add(Constants.UBUNTU_1604_LTS);
             model.add(Constants.WINDOWS_SERVER_2022);
@@ -1848,8 +1851,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
             // First validate the subscription info.  If it is not correct,
             // then we can't validate the
-            String result = AzureClientHolder.getDelegate(azureCredentialsId).verifyConfiguration(resourceGroupName,
-                    maxVirtualMachinesLimit, deploymentTimeout);
+            String result = AzureClientHolder.getDelegate(azureCredentialsId)
+                    .verifyConfiguration(resourceGroupName, deploymentTimeout);
             if (!result.equals(Constants.OP_SUCCESS)) {
                 return FormValidation.error(result);
             }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -1547,8 +1547,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
         public ListBoxModel doFillAgentLaunchMethodItems() {
             ListBoxModel model = new ListBoxModel();
-            model.add(Constants.LAUNCH_METHOD_SSH);
-            model.add(Constants.LAUNCH_METHOD_JNLP);
+            model.add(Messages.AzureVMAgentTemplate_SSH_Agent_Launch_Method(), Constants.LAUNCH_METHOD_SSH);
+            model.add(Messages.AzureVMAgentTemplate_Inbound_Agent_Launch_Method(), Constants.LAUNCH_METHOD_JNLP);
 
             return model;
         }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -1108,7 +1108,6 @@ public class AzureVMCloud extends Cloud {
         @RequirePOST
         public FormValidation doVerifyConfiguration(
                 @QueryParameter String azureCredentialsId,
-                @QueryParameter String maxVirtualMachinesLimit,
                 @QueryParameter String deploymentTimeout,
                 @QueryParameter String resourceGroupReferenceType,
                 @QueryParameter String newResourceGroupName,
@@ -1123,7 +1122,7 @@ public class AzureVMCloud extends Cloud {
             AzureResourceManager azureClient = AzureResourceManagerCache.get(azureCredentialsId);
             final String validationResult = AzureVMManagementServiceDelegate
                     .getInstance(azureClient, azureCredentialsId)
-                    .verifyConfiguration(resourceGroupName, maxVirtualMachinesLimit, deploymentTimeout);
+                    .verifyConfiguration(resourceGroupName, deploymentTimeout);
             if (!validationResult.equalsIgnoreCase(Constants.OP_SUCCESS)) {
                 return FormValidation.error(validationResult);
             }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudVerificationTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudVerificationTask.java
@@ -170,7 +170,6 @@ public final class AzureVMCloudVerificationTask extends AsyncPeriodicWork {
         // Check the sub and off we go
         String result = cloud.getServiceDelegate().verifyConfiguration(
                 cloud.getResourceGroupName(),
-                Integer.toString(cloud.getMaxVirtualMachinesLimit()),
                 Integer.toString(cloud.getDeploymentTimeout()));
         if (!Constants.OP_SUCCESS.equals(result)) {
             LOGGER.log(getStaticNormalLoggingLevel(), "AzureVMCloudVerificationTask: verifyConfiguration: {0}", result);

--- a/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
@@ -427,19 +427,6 @@ public final class AzureUtil {
     }
 
     /**
-     * Checks if the maximum virtual machines limit is valid.
-     *
-     * @param maxVMLimit Maximum Virtual Limit
-     * @return true if it is valid else return false
-     */
-    public static boolean isValidMAxVMLimit(String maxVMLimit) {
-        if (StringUtils.isBlank(maxVMLimit) || !maxVMLimit.matches(Constants.REG_EX_DIGIT)) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
      * Checks if the deployment Timeout is valid.
      *
      * @param deploymentTimeout Deployment Timeout

--- a/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
@@ -121,6 +121,7 @@ public final class Constants {
     public static final String WINDOWS_SERVER_2016 = "Windows Server 2016";
     public static final String UBUNTU_1604_LTS = "Ubuntu 16.04 LTS";
     public static final String UBUNTU_2004_LTS = "Ubuntu 20.04 LTS";
+    public static final String UBUNTU_2204_LTS = "Ubuntu 22.04 LTS";
 
     /**
      * ResourceGroup reference type.

--- a/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
@@ -101,3 +101,6 @@ SA_Blank_Create_New=(Leave blank to create a new storage account)
 Azure_VM_Agent_Attach_Public_IP_Success=Successfully attached a public IP
 Azure_VM_Agent_Attach_Public_IP_Failure=Failed to attach a public IP
 Azure_GC_Template_NSG_NotFound=The Network Security Group {0} does not exist in the Resource Group.
+
+AzureVMAgentTemplate.Inbound_Agent_Launch_Method=Launch agent by connecting it to the controller
+AzureVMAgentTemplate.SSH_Agent_Launch_Method=Launch agents via SSH

--- a/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
@@ -104,3 +104,4 @@ Azure_GC_Template_NSG_NotFound=The Network Security Group {0} does not exist in 
 
 AzureVMAgentTemplate.Inbound_Agent_Launch_Method=Launch agent by connecting it to the controller
 AzureVMAgentTemplate.SSH_Agent_Launch_Method=Launch agents via SSH
+

--- a/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/Messages.properties
@@ -1,8 +1,7 @@
 # Global configuration - validations
 Azure_Config_Success=Successfully verified Azure configuration.
 Azure_GC_InitScript_Warn_Msg=Ensure image is pre-configured with a Java runtime or provide a script \
-  to install Java in headless (silent) mode. \
-                             \nIf using JNLP, see README.md for a sample script.
+  to install Java in headless (silent) mode.
 Azure_GC_LaunchMethod_Warn_Msg=Make sure the Azure agent can reach the controller via the Jenkins URL. \
   Refer to the help for details.
 Azure_GC_TemplateStatus_Warn_Msg=The template is marked as disabled. Check the template status details in \
@@ -65,7 +64,6 @@ Azure_GC_Template_ImageID_Not_Valid=The provided Image ID does not exist
 Azure_GC_Template_Gallery_Image_Not_Found=The target gallery image does not exist
 Azure_GC_Template_ImageURI_Not_In_Same_Account=The image URI is not located in the same storage account as the target \
   storage account for the VM
-Azure_GC_Template_JNLP_Not_Supported=The JNLP launch method is supported only for Windows.
 Azure_GC_Template_UN_Null_Or_Empty=Missing admin user name.
 Azure_GC_Template_PWD_Null_Or_Empty=Missing admin password.
 Azure_GC_Template_PWD_Not_Valid=Required: Not a valid password. The password length must be between 12 and 123 \

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -113,7 +113,7 @@
                     "properties": {
                         "publisher": "Microsoft.Compute",
                         "type": "CustomScriptExtension",
-                        "typeHandlerVersion": "1.7",
+                        "typeHandlerVersion": "1.10",
                         "autoUpgradeMinorVersion": true,
                         "settings": {
                             "fileUris": [
@@ -126,7 +126,34 @@
                             "storageAccountKey": "[parameters('storageAccountKey')]"
                         }
                     }
+                },
+                {
+                    "type": "extensions",
+                    "name": "[concat('customScript', variables('vmName'), copyIndex())]",
+                    "apiVersion": "2020-06-01",
+                    "location": "[variables('location')]",
+                    "dependsOn": [
+                        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
+                    ],
+                    "properties": {
+                        "publisher": "Microsoft.Azure.Extensions",
+                        "type": "CustomScript",
+                        "typeHandlerVersion": "2.1",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                            "skipDos2Unix": true,
+                            "fileUris": [
+                                "[variables('startupScriptURI')]"
+                            ],
+                            "commandToExecute": "[concat('bash ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+                        },
+                        "protectedSettings": {
+                            "storageAccountName": "[variables('storageAccountName')]",
+                            "storageAccountKey": "[parameters('storageAccountKey')]"
+                        }
+                    }
                 }
+
             ],
             "tags": {
                 "JenkinsManagedTag": "[variables('jenkinsTag')]",

--- a/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
@@ -133,13 +133,39 @@
                     "properties": {
                         "publisher": "Microsoft.Compute",
                         "type": "CustomScriptExtension",
-                        "typeHandlerVersion": "1.7",
+                        "typeHandlerVersion": "1.10",
                         "autoUpgradeMinorVersion": true,
                         "settings": {
                             "fileUris": [
                                 "[variables('startupScriptURI')]"
                             ],
                             "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+                        },
+                        "protectedSettings": {
+                            "storageAccountName": "[variables('storageAccountName')]",
+                            "storageAccountKey": "[parameters('storageAccountKey')]"
+                        }
+                    }
+                },
+                {
+                    "type": "extensions",
+                    "name": "[concat('customScript', variables('vmName'), copyIndex())]",
+                    "apiVersion": "2020-06-01",
+                    "location": "[variables('location')]",
+                    "dependsOn": [
+                        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
+                    ],
+                    "properties": {
+                        "publisher": "Microsoft.Azure.Extensions",
+                        "type": "CustomScript",
+                        "typeHandlerVersion": "2.1",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                            "skipDos2Unix": true,
+                            "fileUris": [
+                                "[variables('startupScriptURI')]"
+                            ],
+                            "commandToExecute": "[concat('bash ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
                         },
                         "protectedSettings": {
                             "storageAccountName": "[variables('storageAccountName')]",

--- a/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
@@ -112,13 +112,39 @@
                     "properties": {
                         "publisher": "Microsoft.Compute",
                         "type": "CustomScriptExtension",
-                        "typeHandlerVersion": "1.7",
+                        "typeHandlerVersion": "1.10",
                         "autoUpgradeMinorVersion": true,
                         "settings": {
                             "fileUris": [
                                 "[variables('startupScriptURI')]"
                             ],
                             "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+                        },
+                        "protectedSettings": {
+                            "storageAccountName": "[variables('storageAccountName')]",
+                            "storageAccountKey": "[parameters('storageAccountKey')]"
+                        }
+                    }
+                },
+                {
+                    "type": "extensions",
+                    "name": "[concat('customScript', variables('vmName'), copyIndex())]",
+                    "apiVersion": "2020-06-01",
+                    "location": "[variables('location')]",
+                    "dependsOn": [
+                        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
+                    ],
+                    "properties": {
+                        "publisher": "Microsoft.Azure.Extensions",
+                        "type": "CustomScript",
+                        "typeHandlerVersion": "2.1",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                            "skipDos2Unix": true,
+                            "fileUris": [
+                                "[variables('startupScriptURI')]"
+                            ],
+                            "commandToExecute": "[concat('bash ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
                         },
                         "protectedSettings": {
                             "storageAccountName": "[variables('storageAccountName')]",

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -116,13 +116,39 @@
                     "properties": {
                         "publisher": "Microsoft.Compute",
                         "type": "CustomScriptExtension",
-                        "typeHandlerVersion": "1.7",
+                        "typeHandlerVersion": "1.10",
                         "autoUpgradeMinorVersion": true,
                         "settings": {
                             "fileUris": [
                                 "[variables('startupScriptURI')]"
                             ],
                             "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+                        },
+                        "protectedSettings": {
+                            "storageAccountName": "[variables('storageAccountName')]",
+                            "storageAccountKey": "[parameters('storageAccountKey')]"
+                        }
+                    }
+                },
+                {
+                    "type": "extensions",
+                    "name": "[concat('customScript', variables('vmName'), copyIndex())]",
+                    "apiVersion": "2020-06-01",
+                    "location": "[variables('location')]",
+                    "dependsOn": [
+                        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
+                    ],
+                    "properties": {
+                        "publisher": "Microsoft.Azure.Extensions",
+                        "type": "CustomScript",
+                        "typeHandlerVersion": "2.1",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                            "skipDos2Unix": true,
+                            "fileUris": [
+                                "[variables('startupScriptURI')]"
+                            ],
+                            "commandToExecute": "[concat('bash ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
                         },
                         "protectedSettings": {
                             "storageAccountName": "[variables('storageAccountName')]",

--- a/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
@@ -115,7 +115,7 @@
                     "properties": {
                         "publisher": "Microsoft.Compute",
                         "type": "CustomScriptExtension",
-                        "typeHandlerVersion": "1.7",
+                        "typeHandlerVersion": "1.10",
                         "autoUpgradeMinorVersion": true,
                         "settings": {
                             "fileUris": [
@@ -127,6 +127,32 @@
                             "storageAccountName": "[variables('storageAccountName')]",
                             "storageAccountKey": "[parameters('storageAccountKey')]"
                       }
+                    }
+                },
+                {
+                    "type": "extensions",
+                    "name": "[concat('customScript', variables('vmName'), copyIndex())]",
+                    "apiVersion": "2020-06-01",
+                    "location": "[variables('location')]",
+                    "dependsOn": [
+                        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
+                    ],
+                    "properties": {
+                        "publisher": "Microsoft.Azure.Extensions",
+                        "type": "CustomScript",
+                        "typeHandlerVersion": "2.1",
+                        "autoUpgradeMinorVersion": true,
+                        "settings": {
+                            "skipDos2Unix": true,
+                            "fileUris": [
+                                "[variables('startupScriptURI')]"
+                            ],
+                            "commandToExecute": "[concat('bash ', variables('startupScriptName'),' ', variables('jenkinsServerURL'),' ', variables('vmName'),copyIndex(),' ', variables('clientSecrets')[copyIndex()])]"
+                        },
+                        "protectedSettings": {
+                            "storageAccountName": "[variables('storageAccountName')]",
+                            "storageAccountKey": "[parameters('storageAccountKey')]"
+                        }
                     }
                 }
             ],

--- a/src/main/resources/scripts/init.ps1
+++ b/src/main/resources/scripts/init.ps1
@@ -1,4 +1,4 @@
-# Install Agent jar and connect via JNLP
+# Install Agent jar and connect as an Inbound agent
 # Jenkins plugin will dynamically pass the server name and vm name.
 # If your jenkins server is configured for security , make sure to edit command for how agent executes
 $jenkinsserverurl = $args[0]

--- a/src/main/resources/scripts/ubuntuInstallMavenScript.sh
+++ b/src/main/resources/scripts/ubuntuInstallMavenScript.sh
@@ -1,6 +1,6 @@
 # Install Maven
 
-MAVEN_VERSION=3.8.6
+MAVEN_VERSION=3.9.1
 
 sudo curl -O "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
 sudo tar zxvf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt/

--- a/src/main/webapp/help-initScript.html
+++ b/src/main/webapp/help-initScript.html
@@ -5,7 +5,7 @@
     Below are examples of initialization scripts, Java is <b>required</b>, others are optional:
     <ol>
       <li>
-        <b>Ubuntu (Only support SSH)</b>
+        <b>Ubuntu via SSH</b>
         <p>
           <pre><code># Install Java
 sudo apt-get -y update
@@ -17,7 +17,7 @@ java -version
 sudo apt-get install -y git
 
 # Install Maven
-MAVEN_VERSION=3.8.4
+MAVEN_VERSION=3.9.1
 
 sudo curl -O https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
 sudo tar zxvf apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt/
@@ -40,12 +40,19 @@ sudo docker --version
         </pre>
       </p>
       </li>
+    <li>
+        <b>Ubuntu as an inbound agent</b>
+        <p>
+            You can use this <a target="_blank" href="https://raw.githubusercontent.com/jenkinsci/azure-vm-agents-plugin/master/docs/init-scripts/linux-inbound-agent.ps1">sample</a>.<br>
+            Java, the agent jar and connecting to Jenkins are <b>required</b>, others are optional.
+        </p>
+    </li>
       <li>
         <b>Windows via SSH</b>
         <p>
           You can use this <a target="_blank" href="https://raw.githubusercontent.com/jenkinsci/azure-vm-agents-plugin/master/docs/init-scripts/windows-ssh.ps1">sample</a>.<br>
           Java is <b>required</b>, others are optional.<br>
-          We recommend to use SSH rather than inbound agent. You need less init code and get much clearer logs.
+          We recommend to use SSH rather than inbound agent. It's simpler to setup and you get much clearer logs.
         </p>
       </li>
       <li>
@@ -64,7 +71,7 @@ sudo docker --version
         </p>
         <p>
           The server url should already have a trailing slash.  Then execute the following to connect:
-          <pre><code>java.exe -jar [slave jar location] [-secret [client secret if required]] [server url]computer/[vm name]/slave-agent.jnlp</code></pre>
+          <pre><code>java.exe -jar [agent jar location] [-secret [client secret if required]] [server url]computer/[vm name]/jenkins-agent.jnlp</code></pre>
         </p>
       </li>
     </ol>


### PR DESCRIPTION
I've tested both linux and windows inbound agents with this method all seems to be working fine

Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/311

Relates to https://github.com/jenkins-infra/helpdesk/issues/3529

cc @dduportal 

TODO:

- [ ] Linux sample script should run the agent as a service in case agent is rebooted
- [x] Update UI field to not use JNLP in dropdown text
- [ ] Ideally move ssh / inbound agent specific fields to nested under the Launch Method
