### PR TITLE
Add option to enable encryption at host

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -129,6 +129,8 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
 
     private final boolean ephemeralOSDisk;
 
+    private final boolean encryptionAtHost;
+
     private final String uamiID;
 
     private String javaPath;
@@ -177,6 +179,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
             boolean enableMSI,
             boolean enableUAMI,
             boolean ephemeralOSDisk,
+            boolean encryptionAtHost,
             String uamiID,
             String javaPath,
             String remotingOptions,
@@ -215,6 +218,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
         this.enableMSI = enableMSI;
         this.enableUAMI = enableUAMI;
         this.ephemeralOSDisk = ephemeralOSDisk;
+        this.encryptionAtHost = encryptionAtHost;
         this.uamiID = uamiID;
         this.template = template;
         this.creationTime = System.currentTimeMillis();
@@ -252,6 +256,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
             boolean enableMSI,
             boolean enableUAMI,
             boolean ephemeralOSDisk,
+            boolean encryptionAtHost,
             String uamiID,
             AzureVMAgentTemplate template,
             String fqdn,
@@ -296,6 +301,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
                 enableMSI,
                 enableUAMI,
                 ephemeralOSDisk,
+                encryptionAtHost,
                 uamiID,
                 javaPath,
                 remotingOptions,
@@ -506,6 +512,10 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
 
     public boolean isEphemeralOSDisk() {
         return ephemeralOSDisk;
+    }
+
+    public boolean isEncryptionAtHost() {
+        return encryptionAtHost;
     }
 
     public AzureVMAgentTemplate getTemplate() {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -270,6 +270,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
     private boolean ephemeralOSDisk;
 
+    private boolean encryptionAtHost;
+
     private int osDiskSize;
 
     private String newStorageAccountName;
@@ -719,6 +721,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
                 isBasic ? false : template.isEnableUAMI());
         templateProperties.put("ephemeralOSDisk",
                 isBasic ? false : template.isEphemeralOSDisk());
+        templateProperties.put("encryptionAtHost",
+                isBasic ? false : template.isEncryptionAtHost());
         templateProperties.put("uamiID",
                 isBasic ? "" : template.getUamiID());
 
@@ -975,6 +979,15 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
     @DataBoundSetter
     public void setEphemeralOSDisk(boolean ephemeralOSDisk) {
         this.ephemeralOSDisk = ephemeralOSDisk;
+    }
+
+    public boolean isEncryptionAtHost() {
+        return encryptionAtHost;
+    }
+
+    @DataBoundSetter
+    public void setEncryptionAtHost(boolean encryptionAtHost) {
+        this.encryptionAtHost = encryptionAtHost;
     }
 
     @DataBoundSetter
@@ -1554,7 +1567,6 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
             }
             return model;
         }
-
 
         public ListBoxModel doFillUsageModeItems() throws IOException, ServletException {
             ListBoxModel model = new ListBoxModel();

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -228,6 +228,7 @@ public final class AzureVMManagementServiceDelegate {
             final String storageAccountType = template.getStorageAccountType();
             final String diskType = template.getDiskType();
             final boolean ephemeralOSDisk = template.isEphemeralOSDisk();
+            final boolean encryptionAtHost = template.isEncryptionAtHost();
             final int osDiskSize = template.getOsDiskSize();
             final AzureVMAgentTemplate.AvailabilityTypeClass availabilityType = template.getAvailabilityType();
             final String availabilitySet = availabilityType != null ? availabilityType.getAvailabilitySet() : null;
@@ -495,6 +496,7 @@ public final class AzureVMManagementServiceDelegate {
             copyVariableIfNotBlank(tmp, properties, "imageVersion");
             copyVariableIfNotBlank(tmp, properties, "osType");
             putVariable(tmp, "ephemeralOSDisk", Boolean.toString(ephemeralOSDisk));
+            putVariable(tmp, "encryptionAtHost", Boolean.toString(encryptionAtHost));
             putVariableIfNotBlank(tmp, "image", template.getImageReference().getUri());
 
             String imageId = getImageId(properties);
@@ -1158,6 +1160,7 @@ public final class AzureVMManagementServiceDelegate {
                     (Boolean) properties.get("enableMSI"),
                     (Boolean) properties.get("enableUAMI"),
                     (Boolean) properties.get("ephemeralOSDisk"),
+                    (Boolean) properties.get("encryptionAtHost"),
                     (String) properties.get("uamiID"),
                     template,
                     fqdn,

--- a/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateFluent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateFluent.java
@@ -34,6 +34,8 @@ public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
 
     private boolean ephemeralOSDisk;
 
+    private boolean encryptionAtHost;
+
     private int osDiskSize;
 
     private String newStorageAccountName;
@@ -138,6 +140,11 @@ public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
 
     public T withEphemeralOSDisk(boolean isEphemeral) {
         this.ephemeralOSDisk = isEphemeral;
+        return (T) this;
+    }
+
+    public T withEncryptionAtHost(boolean isEncryptionAtHost) {
+        this.encryptionAtHost = isEncryptionAtHost;
         return (T) this;
     }
 
@@ -248,6 +255,10 @@ public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
 
     public boolean isEphemeralOSDisk() {
         return ephemeralOSDisk;
+    }
+
+    public boolean isEncryptionAtHost() {
+        return encryptionAtHost;
     }
 
     public int getOsDiskSize() {

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
@@ -112,6 +112,10 @@
             <f:textbox/>
           </f:entry>
 
+          <f:entry title="${%Enable_Encryption_At_Host}" field="encryptionAtHost">
+            <f:checkbox/>
+          </f:entry>
+
           <f:dropdownDescriptorSelector field="retentionStrategy" title="${%Retention_Strategy}"
                                         descriptors="${descriptor.azureVMRetentionStrategy}"/>
 

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
@@ -17,7 +17,7 @@ noOfParallelJobs=Number of executors
 Image_Configuration=Image configuration
 Disk_Type=Choose disks type
 Use_Ephemeral_OS_Disk=Use Ephemeral OS disk
-Enable_Encryption_At_Host=Enable Encryption At Host
+Enable_Encryption_At_Host=Enable encryption at host
 OS_Disk_Size=OS disk size in GB (Optional)
 Retention_Strategy=Retention strategy
 

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.properties
@@ -17,6 +17,7 @@ noOfParallelJobs=Number of executors
 Image_Configuration=Image configuration
 Disk_Type=Choose disks type
 Use_Ephemeral_OS_Disk=Use Ephemeral OS disk
+Enable_Encryption_At_Host=Enable Encryption At Host
 OS_Disk_Size=OS disk size in GB (Optional)
 Retention_Strategy=Retention strategy
 

--- a/src/main/resources/customImageTemplate.json
+++ b/src/main/resources/customImageTemplate.json
@@ -102,7 +102,7 @@
                     ]
                 },
                 "securityProfile": {
-                    "encryptionAtHost": "[variables('encryptionAtHost')]"
+                    "encryptionAtHost": "[if(bool(variables('encryptionAtHost')), json('true'), json('null'))]"
                 }
             },
             "tags": {

--- a/src/main/resources/customImageTemplate.json
+++ b/src/main/resources/customImageTemplate.json
@@ -88,6 +88,9 @@
                             "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'), copyIndex(), 'NIC'))]"
                         }
                     ]
+                },
+                "securityProfile": {
+                    "encryptionAtHost": "[variables('encryptionAtHost')]"
                 }
             },
             "tags": {

--- a/src/main/resources/customImageTemplateWithManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithManagedDisk.json
@@ -125,7 +125,7 @@
                     ]
                 },
                 "securityProfile": {
-                    "encryptionAtHost": "[variables('encryptionAtHost')]"
+                    "encryptionAtHost": "[if(bool(variables('encryptionAtHost')), json('true'), json('null'))]"
                 }
             },
             "tags": {

--- a/src/main/resources/customImageTemplateWithManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithManagedDisk.json
@@ -32,7 +32,7 @@
                         "blobUri": "[variables('image')]",
                         "storageAccountType": "[variables('storageAccountType')]"
                     }
-                }
+               }
             },
             "tags": {
                 "JenkinsManagedTag": "[variables('jenkinsTag')]",
@@ -111,6 +111,9 @@
                             }
                         }
                     ]
+                },
+                "securityProfile": {
+                    "encryptionAtHost": "[variables('encryptionAtHost')]"
                 }
             },
             "tags": {

--- a/src/main/resources/customImageTemplateWithManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithManagedDisk.json
@@ -43,7 +43,7 @@
                         "blobUri": "[variables('image')]",
                         "storageAccountType": "[variables('storageAccountType')]"
                     }
-               }
+                }
             },
             "tags": {
                 "JenkinsManagedTag": "[variables('jenkinsTag')]",

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -99,6 +99,9 @@
                             }
                         }
                     ]
+                },
+                "securityProfile": {
+                    "encryptionAtHost": "[variables('encryptionAtHost')]"
                 }
             },
             "resources": [

--- a/src/main/resources/customImageTemplateWithScript.json
+++ b/src/main/resources/customImageTemplateWithScript.json
@@ -113,7 +113,7 @@
                     ]
                 },
                 "securityProfile": {
-                    "encryptionAtHost": "[variables('encryptionAtHost')]"
+                    "encryptionAtHost": "[if(bool(variables('encryptionAtHost')), json('true'), json('null'))]"
                 }
             },
             "resources": [

--- a/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
@@ -119,6 +119,9 @@
                             }
                         }
                     ]
+                },
+                "securityProfile": {
+                    "encryptionAtHost": "[variables('encryptionAtHost')]"
                 }
             },
             "resources": [

--- a/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/customImageTemplateWithScriptAndManagedDisk.json
@@ -133,7 +133,7 @@
                     ]
                 },
                 "securityProfile": {
-                    "encryptionAtHost": "[variables('encryptionAtHost')]"
+                    "encryptionAtHost": "[if(bool(variables('encryptionAtHost')), json('true'), json('null'))]"
                 }
             },
             "resources": [

--- a/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
@@ -90,6 +90,9 @@
                             }
                         }
                     ]
+                },
+                "securityProfile": {
+                    "encryptionAtHost": "[variables('encryptionAtHost')]"
                 }
             },
             "tags": {

--- a/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithManagedDisk.json
@@ -104,7 +104,7 @@
                     ]
                 },
                 "securityProfile": {
-                    "encryptionAtHost": "[variables('encryptionAtHost')]"
+                    "encryptionAtHost": "[if(bool(variables('encryptionAtHost')), json('true'), json('null'))]"
                 }
             },
             "tags": {

--- a/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
@@ -112,7 +112,7 @@
                     ]
                 },
                 "securityProfile": {
-                    "encryptionAtHost": "[variables('encryptionAtHost')]"
+                    "encryptionAtHost": "[if(bool(variables('encryptionAtHost')), json('true'), json('null'))]"
                 }
             },
             "resources": [

--- a/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageIDTemplateWithScriptAndManagedDisk.json
@@ -98,6 +98,9 @@
                             }
                         }
                     ]
+                },
+                "securityProfile": {
+                    "encryptionAtHost": "[variables('encryptionAtHost')]"
                 }
             },
             "resources": [

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -94,6 +94,9 @@
                             }
                         }
                     ]
+                },
+                "securityProfile": {
+                    "encryptionAtHost": "[variables('encryptionAtHost')]"
                 }
             },
             "tags": {

--- a/src/main/resources/referenceImageTemplate.json
+++ b/src/main/resources/referenceImageTemplate.json
@@ -108,7 +108,7 @@
                     ]
                 },
                 "securityProfile": {
-                    "encryptionAtHost": "[variables('encryptionAtHost')]"
+                    "encryptionAtHost": "[if(bool(variables('encryptionAtHost')), json('true'), json('null'))]"
                 }
             },
             "tags": {

--- a/src/main/resources/referenceImageTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithManagedDisk.json
@@ -107,7 +107,7 @@
                     ]
                 },
                 "securityProfile": {
-                    "encryptionAtHost": "[variables('encryptionAtHost')]"
+                    "encryptionAtHost": "[if(bool(variables('encryptionAtHost')), json('true'), json('null'))]"
                 }
             },
             "tags": {

--- a/src/main/resources/referenceImageTemplateWithManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithManagedDisk.json
@@ -93,6 +93,9 @@
                             }
                         }
                     ]
+                },
+                "securityProfile": {
+                    "encryptionAtHost": "[variables('encryptionAtHost')]"
                 }
             },
             "tags": {

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -116,7 +116,7 @@
                     ]
                 },
                 "securityProfile": {
-                    "encryptionAtHost": "[variables('encryptionAtHost')]"
+                    "encryptionAtHost": "[if(bool(variables('encryptionAtHost')), json('true'), json('null'))]"
                 }
             },
             "resources": [

--- a/src/main/resources/referenceImageTemplateWithScript.json
+++ b/src/main/resources/referenceImageTemplateWithScript.json
@@ -102,6 +102,9 @@
                             }
                         }
                     ]
+                },
+                "securityProfile": {
+                    "encryptionAtHost": "[variables('encryptionAtHost')]"
                 }
             },
             "resources": [

--- a/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
@@ -115,7 +115,7 @@
                     ]
                 },
                 "securityProfile": {
-                    "encryptionAtHost": "[variables('encryptionAtHost')]"
+                    "encryptionAtHost": "[if(bool(variables('encryptionAtHost')), json('true'), json('null'))]"
                 }
             },
             "resources": [

--- a/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
+++ b/src/main/resources/referenceImageTemplateWithScriptAndManagedDisk.json
@@ -101,6 +101,9 @@
                             }
                         }
                     ]
+                },
+                "securityProfile": {
+                    "encryptionAtHost": "[variables('encryptionAtHost')]"
                 }
             },
             "resources": [


### PR DESCRIPTION
Added option to enable encryption at host when provisioning VMs.

https://github.com/jenkinsci/azure-vm-agents-plugin/issues/415

### Testing done
Tested provisioning VMs on a subscription where encryption at host is mandatory.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
