### PR TITLE
remove redundant cloudName

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -94,8 +94,6 @@ public class AzureVMCloud extends Cloud {
     private static final int DEFAULT_SSH_CONNECT_RETRY_COUNT = 3;
     private static final int SHH_CONNECT_RETRY_INTERNAL_SECONDS = 20;
 
-    private final String cloudName;
-
     private final String credentialsId;
 
     private final int maxVirtualMachinesLimit;
@@ -159,7 +157,6 @@ public class AzureVMCloud extends Cloud {
         this.existingResourceGroupName = existingResourceGroupName;
         this.resourceGroupName = getResourceGroupName(
                 resourceGroupReferenceType, newResourceGroupName, existingResourceGroupName);
-        this.cloudName = getOrGenerateCloudName(cloudName, azureCredentialsId, this.resourceGroupName);
 
         if (StringUtils.isBlank(maxVirtualMachinesLimit) || !maxVirtualMachinesLimit.matches(Constants.REG_EX_DIGIT)) {
             this.maxVirtualMachinesLimit = Constants.DEFAULT_MAX_VM_LIMIT;
@@ -268,7 +265,7 @@ public class AzureVMCloud extends Cloud {
     }
 
     public String getCloudName() {
-        return cloudName;
+        return this.name;
     }
 
     public static String getOrGenerateCloudName(String cloudName, String credentialId, String resourceGroupName) {
@@ -616,7 +613,7 @@ public class AzureVMCloud extends Cloud {
         final List<PlannedNode> plannedNodes = new ArrayList<>(numberOfAgents);
 
         if (!template.getTemplateProvisionStrategy().isVerifiedPass()) {
-            AzureVMCloudVerificationTask.verify(cloudName, template.getTemplateName());
+            AzureVMCloudVerificationTask.verify(this.name, template.getTemplateName());
         }
         if (template.getTemplateProvisionStrategy().isVerifiedFailed()) {
             LOGGER.log(Level.INFO, "Template {0} has just verified failed", template.getTemplateName());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
I noticed the usage of `cloudName` is redundant.
In the constructor of `AzureVMCloud`, the constructor to the `super.name` (i.e. `Cloud.name`) is identical to `AzureVMCloud.cloudName`.  

### Testing done
Manual testing: changing of the cloud name in the config page still works.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
