### PR TITLE
[JENKINS-71737] rename cloudName to name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <gitHubRepo>jenkinsci/azure-vm-agents-plugin</gitHubRepo>
         <jenkins.version>2.387.3</jenkins.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <hpi.compatibleSinceVersion>846</hpi.compatibleSinceVersion>
+        <hpi.compatibleSinceVersion>883</hpi.compatibleSinceVersion>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -135,7 +135,7 @@ public class AzureVMCloud extends Cloud {
 
     @DataBoundConstructor
     public AzureVMCloud(
-            String cloudName,
+            String name,
             String azureCredentialsId,
             String maxVirtualMachinesLimit,
             String deploymentTimeout,
@@ -145,7 +145,7 @@ public class AzureVMCloud extends Cloud {
             List<AzureVMAgentTemplate> vmTemplates) {
         super(
                 getOrGenerateCloudName(
-                        cloudName,
+                        name,
                         azureCredentialsId,
                         getResourceGroupName(
                                 resourceGroupReferenceType,
@@ -268,10 +268,10 @@ public class AzureVMCloud extends Cloud {
         return this.name;
     }
 
-    public static String getOrGenerateCloudName(String cloudName, String credentialId, String resourceGroupName) {
-        return StringUtils.isBlank(cloudName)
+    public static String getOrGenerateCloudName(String name, String credentialId, String resourceGroupName) {
+        return StringUtils.isBlank(name)
                 ? AzureUtil.getCloudName(credentialId, resourceGroupName)
-                : cloudName;
+                : name;
     }
 
     public String getNewResourceGroupName() {

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMCloud/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMCloud/config.jelly
@@ -4,7 +4,7 @@
   <f:block>
     <a href="${rootURL}/log/${descriptor.logRecorderName}/" target="_blank">${%Azure_VM_Agent_Log_Link}</a>
   </f:block>
-  <f:entry title="${%Cloud_Name}" field="cloudName"
+  <f:entry title="${%Cloud_Name}" field="name"
            help="/plugin/azure-vm-agents/help-cloudName.html">
     <f:textbox/>
   </f:entry>

--- a/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/advanced.yaml
+++ b/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/advanced.yaml
@@ -2,7 +2,7 @@ jenkins:
   clouds:
     - azureVM:
         azureCredentialsId: "azure-cred"
-        cloudName: "azure"
+        name: "azure"
         cloudTags:
           - name: "author"
             value: "gavin"

--- a/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/basic.yaml
+++ b/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/basic.yaml
@@ -2,7 +2,7 @@ jenkins:
   clouds:
     - azureVM:
         azureCredentialsId: "azure-cred"
-        cloudName: "azure"
+        name: "azure"
         deploymentTimeout: 1200
         maxVirtualMachinesLimit: 10
         newResourceGroupName: "vm-agent"

--- a/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/expectedAdvanced.yaml
+++ b/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/expectedAdvanced.yaml
@@ -1,12 +1,12 @@
 - azureVM:
     azureCredentialsId: "azure-cred"
-    cloudName: "azure"
     cloudTags:
     - name: "author"
       value: "gavin"
     deploymentTimeout: 1200
     existingResourceGroupName: "vm-agents"
     maxVirtualMachinesLimit: 10
+    name: "azure"
     resourceGroupReferenceType: "existing"
     vmTemplates:
     - agentWorkspace: "/opt/jenkins"

--- a/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/expectedBasic.yaml
+++ b/src/test/resources/com/microsoft/azure/vmagent/test/jcasc/expectedBasic.yaml
@@ -1,8 +1,8 @@
 - azureVM:
     azureCredentialsId: "azure-cred"
-    cloudName: "azure"
     deploymentTimeout: 1200
     maxVirtualMachinesLimit: 10
+    name: "azure"
     newResourceGroupName: "vm-agent"
     resourceGroupReferenceType: "new"
     vmTemplates:


### PR DESCRIPTION
> [!WARNING]
> This is a breaking change for anyone configuring Azure VM Agents with the configuration as code plugin

`cloudName` has been renamed to `name` adapt your templates

```diff
- cloudName: "linux"
+ name: "linux" 
```


<!-- Please describe your pull request here. -->
Preparing for https://github.com/jenkinsci/jenkins/pull/8310 where cloud name changes will be done on a separate page

The use of the variable name cloudName in AmazonEC2Cloud forces jenkins core to have a special case of handling cloudName when it not a variable of Cloud.
https://github.com/jenkinsci/jenkins/blob/d41b0f5807923286ad33d4847af95e2c6c7c77ba/core/src/main/java/jenkins/agents/CloudSet.java#L229

upstream of #460 

### Testing done
manually created, renamed, and deleted an `AzureVMAgentsCloud`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
