### PR TITLE
Skip cleanup when not configured with a valid client

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -331,7 +331,9 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
             final AzureResourceManager azureClient = cloud.getAzureClient();
 
             if (azureClient == null) {
-                LOGGER.log(getNormalLoggingLevel(), "cleanLeakedResources: Skipping cleanup as cloud is not configured with a valid credential");
+                LOGGER.log(getNormalLoggingLevel(),
+                        "cleanLeakedResources: Skipping cleanup as cloud is not configured with a "
+                                + "valid credential");
                 return;
             }
 

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -329,6 +329,12 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
         try {
             final List<String> validVMs = getValidVMs();
             final AzureResourceManager azureClient = cloud.getAzureClient();
+
+            if (azureClient == null) {
+                LOGGER.log(getNormalLoggingLevel(), "cleanLeakedResources: Skipping cleanup as cloud is not configured with a valid credential");
+                return;
+            }
+
             final AzureVMManagementServiceDelegate serviceDelegate = cloud.getServiceDelegate();
             // can't use listByTag because for some reason that method strips all the tags from the outputted resources
             // (https://github.com/Azure/azure-sdk-for-java/issues/1436)


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Requires https://github.com/jenkinsci/azure-credentials-plugin/pull/236

### Testing done

Loaded this plugin build in a controller that's not got a valid config and I'm no longer getting stacktraces but just:
```
2023-12-16 16:49:43.448+0000 [id=284]	INFO	c.m.a.v.AzureVMAgentCleanUpTask#cleanLeakedResources: cleanLeakedResources: Skipping cleanup as cloud is not configured with a valid credential
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
