### PR TITLE
Add option for single-use agents in pool retention strategy

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
@@ -16,6 +16,7 @@ import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.RetentionStrategy;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,18 +31,26 @@ public class AzureVMCloudPoolRetentionStrategy extends AzureVMCloudBaseRetention
 
     private final int poolSize;
 
-    private final boolean singleUseAgents;
+    private boolean singleUseAgents;
 
     private static final long IDLE_LIMIT_MILLIS = TimeUnit.MINUTES.toMillis(1);
 
     private static final Logger LOGGER = Logger.getLogger(AzureVMManagementServiceDelegate.class.getName());
 
-    @DataBoundConstructor
+    @Deprecated
     public AzureVMCloudPoolRetentionStrategy(int retentionInHours, int poolSize, boolean singleUseAgents) {
         retentionInHours = Math.max(retentionInHours, 0);
         this.retentionMillis = TimeUnit.HOURS.toMillis(retentionInHours);
         this.poolSize = Math.max(poolSize, 0);
         this.singleUseAgents = singleUseAgents;
+    }
+
+    @DataBoundConstructor
+    public AzureVMCloudPoolRetentionStrategy(int retentionInHours, int poolSize) {
+        retentionInHours = Math.max(retentionInHours, 0);
+        this.retentionMillis = TimeUnit.HOURS.toMillis(retentionInHours);
+        this.poolSize = Math.max(poolSize, 0);
+        this.singleUseAgents = false;
     }
 
     @Override
@@ -212,7 +221,12 @@ public class AzureVMCloudPoolRetentionStrategy extends AzureVMCloudBaseRetention
     }
 
     public boolean isSingleUseAgents() {
-        return singleUseAgents;
+        return this.singleUseAgents;
+    }
+
+    @DataBoundSetter
+    public void setSingleUseAgents(boolean singleUseAgents) {
+        this.singleUseAgents = singleUseAgents;
     }
 
     @Override
@@ -232,7 +246,6 @@ public class AzureVMCloudPoolRetentionStrategy extends AzureVMCloudBaseRetention
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     public static class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {
-
         @Override @NonNull
         public String getDisplayName() {
             return "Azure VM Pool Retention Strategy";

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
@@ -37,7 +37,7 @@ public class AzureVMCloudPoolRetentionStrategy extends AzureVMCloudBaseRetention
 
     private static final Logger LOGGER = Logger.getLogger(AzureVMManagementServiceDelegate.class.getName());
 
-    @Deprecated
+    @DataBoundConstructor
     public AzureVMCloudPoolRetentionStrategy(int retentionInHours, int poolSize, boolean singleUseAgents) {
         retentionInHours = Math.max(retentionInHours, 0);
         this.retentionMillis = TimeUnit.HOURS.toMillis(retentionInHours);
@@ -45,7 +45,7 @@ public class AzureVMCloudPoolRetentionStrategy extends AzureVMCloudBaseRetention
         this.singleUseAgents = singleUseAgents;
     }
 
-    @DataBoundConstructor
+    @Deprecated
     public AzureVMCloudPoolRetentionStrategy(int retentionInHours, int poolSize) {
         retentionInHours = Math.max(retentionInHours, 0);
         this.retentionMillis = TimeUnit.HOURS.toMillis(retentionInHours);

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
@@ -191,7 +191,7 @@ public class AzureVMCloudPoolRetentionStrategy extends AzureVMCloudBaseRetention
         done((AzureVMComputer) computer);
     }
     public void done(AzureVMComputer computer) {
-        if(!isSingleUseAgents()){
+        if (!isSingleUseAgents()) {
             return;
         }
 

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
@@ -45,14 +45,6 @@ public class AzureVMCloudPoolRetentionStrategy extends AzureVMCloudBaseRetention
         this.singleUseAgents = singleUseAgents;
     }
 
-    @Deprecated
-    public AzureVMCloudPoolRetentionStrategy(int retentionInHours, int poolSize) {
-        retentionInHours = Math.max(retentionInHours, 0);
-        this.retentionMillis = TimeUnit.HOURS.toMillis(retentionInHours);
-        this.poolSize = Math.max(poolSize, 0);
-        this.singleUseAgents = false;
-    }
-
     @Override
     public long check(final AzureVMComputer agentComputer) {
         final AzureVMAgent agentNode = agentComputer.getNode();

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy.java
@@ -38,11 +38,10 @@ public class AzureVMCloudPoolRetentionStrategy extends AzureVMCloudBaseRetention
     private static final Logger LOGGER = Logger.getLogger(AzureVMManagementServiceDelegate.class.getName());
 
     @DataBoundConstructor
-    public AzureVMCloudPoolRetentionStrategy(int retentionInHours, int poolSize, boolean singleUseAgents) {
+    public AzureVMCloudPoolRetentionStrategy(int retentionInHours, int poolSize) {
         retentionInHours = Math.max(retentionInHours, 0);
         this.retentionMillis = TimeUnit.HOURS.toMillis(retentionInHours);
         this.poolSize = Math.max(poolSize, 0);
-        this.singleUseAgents = singleUseAgents;
     }
 
     @Override

--- a/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateFluent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateFluent.java
@@ -164,8 +164,10 @@ public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
     }
 
     public T addNewPoolRetentionStrategy(String retentionTime, String poolSize, boolean singleUseAgents) {
-        this.retentionStrategy = new AzureVMCloudPoolRetentionStrategy(Integer.parseInt(retentionTime),
-                Integer.parseInt(poolSize), singleUseAgents);
+        AzureVMCloudPoolRetentionStrategy retentionStrategy1 = new AzureVMCloudPoolRetentionStrategy(Integer.parseInt(retentionTime),
+                Integer.parseInt(poolSize));
+        retentionStrategy1.setSingleUseAgents(singleUseAgents);
+        this.retentionStrategy = retentionStrategy1;
         return (T) this;
     }
 

--- a/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateFluent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateFluent.java
@@ -163,9 +163,9 @@ public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
         return (T) this;
     }
 
-    public T addNewPoolRetentionStrategy(String retentionTime, String poolSize) {
+    public T addNewPoolRetentionStrategy(String retentionTime, String poolSize, boolean singleUseAgents) {
         this.retentionStrategy = new AzureVMCloudPoolRetentionStrategy(Integer.parseInt(retentionTime),
-                Integer.parseInt(poolSize));
+                Integer.parseInt(poolSize), singleUseAgents);
         return (T) this;
     }
 

--- a/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateFluent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/builders/AzureVMTemplateFluent.java
@@ -164,7 +164,8 @@ public class AzureVMTemplateFluent<T extends AzureVMTemplateFluent<T>> {
     }
 
     public T addNewPoolRetentionStrategy(String retentionTime, String poolSize, boolean singleUseAgents) {
-        AzureVMCloudPoolRetentionStrategy retentionStrategy1 = new AzureVMCloudPoolRetentionStrategy(Integer.parseInt(retentionTime),
+        AzureVMCloudPoolRetentionStrategy retentionStrategy1 =
+          new AzureVMCloudPoolRetentionStrategy(Integer.parseInt(retentionTime),
                 Integer.parseInt(poolSize));
         retentionStrategy1.setSingleUseAgents(singleUseAgents);
         this.retentionStrategy = retentionStrategy1;

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy/config.jelly
@@ -9,4 +9,8 @@
         <f:textbox default="3" />
     </f:entry>
 
+    <f:entry title="${%Single_Use_Agents}" field="singleUseAgents">
+        <f:checkbox/>
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy/config.properties
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy/config.properties
@@ -1,2 +1,3 @@
 RetentionTimeInHours=Retention Time In Hour
 Pool_Size=Pool Size
+Single_Use_Agents=Single Use Agents

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy/help-singleUseAgents.html
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMCloudPoolRetentionStrategy/help-singleUseAgents.html
@@ -1,0 +1,3 @@
+<div>
+    If enabled, agents are deleted after a single job is run. It is suggested to set retention time to 0 if this is enabled.
+</div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Added a feature to enable single-use agents for the pool retention strategy. This allows agents to be available immediately (useful for windows agents with long startup times), while still having a fresh agent for each run. 

### Testing done
Ran a cloud with new feature disabled in options, verified that agents do not get removed after jobs are run, and verified agents get cleaned after retention time expires.
Ran cloud with new feature enabled in options, verified that agents get removed after a single job, and verified agents get removed after retention time expires.
Also verified that agents do not get removed due to timeout when timeout is 0.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
