### PR TITLE
Remove node if VM doesn't exist even if computer is not idle

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -499,7 +499,10 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
 
                 // Check if the virtual machine exists.  If not, it could have been
                 // deleted in the background.  Remove from Jenkins if that is the case.
-                LOGGER.log(getNormalLoggingLevel(), "Checking if virtual machine exists for node: {0}", agentNode.getDisplayName());
+                LOGGER.log(getNormalLoggingLevel(),
+                    "Checking if virtual machine exists for node: {0}", 
+                    agentNode.getDisplayName()
+                );
                 if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
                     LOGGER.log(getNormalLoggingLevel(),
                             "Node {0} doesn't exist, removing",

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -499,32 +499,32 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
 
                 // Check if the virtual machine exists.  If not, it could have been
                 // deleted in the background.  Remove from Jenkins if that is the case.
-                // if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
-                //     LOGGER.log(getNormalLoggingLevel(),
-                //             "Node {0} doesn't exist, removing",
-                //             agentNode.getDisplayName());
-                //     try {
-                //         Jenkins.get().removeNode(agentNode);
-                //     } catch (IOException e) {
-                //         LOGGER.log(Level.WARNING,
-                //                 "Node {0} could not be removed: {1}",
-                //                 new Object[]{agentNode.getDisplayName(), e.getMessage()});
-                //     }
-                //     continue;
-                // }
-                // Echo statement to log before the step
-                System.out.println("Checking if virtual machine exists for node: " + agentNode.getDisplayName());
+                LOGGER.log(Level.INFO, "Checking if virtual machine exists for node: {0}", agentNode.getDisplayName());
                 if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
-                    System.out.println("Node " + agentNode.getDisplayName() + " doesn't exist, removing.");
+                    LOGGER.log(getNormalLoggingLevel(),
+                            "Node {0} doesn't exist, removing",
+                            agentNode.getDisplayName());
                     try {
                         Jenkins.get().removeNode(agentNode);
-                        System.out.println("Node " + agentNode.getDisplayName() + " successfully removed.");
                     } catch (IOException e) {
-                        System.out.println("Node " + agentNode.getDisplayName() + " could not be removed: "
-                                          + e.getMessage());
+                        LOGGER.log(Level.WARNING,
+                                "Node {0} could not be removed: {1}",
+                                new Object[]{agentNode.getDisplayName(), e.getMessage()});
                     }
                     continue;
                 }
+                // Echo statement to log before the step
+               // LOGGER.log(Level.INFO, "Checking if virtual machine exists for node: {0}", agentNode.getDisplayName());
+               // if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
+               //     LOGGER.log(Level.INFO, "Node {0} doesn't exist, removing.", agentNode.getDisplayName());
+               //     try {
+               //         Jenkins.get().removeNode(agentNode);
+               //         LOGGER.log(Level.INFO, "Node {0} successfully removed.", agentNode.getDisplayName());
+               //     } catch (IOException e) {
+               //         LOGGER.log(Level.WARNING, "Node {0} could not be removed: {1}", new Object[]{agentNode.getDisplayName(), e.getMessage()});
+               //     }
+               //     continue;
+               // }
 
                 // Machine exists but is in either DELETE or SHUTDOWN state.
                 // Execute that action.

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -471,42 +471,8 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
                 AzureVMComputer azureComputer = (AzureVMComputer) computer;
                 final AzureVMAgent agentNode = azureComputer.getNode();
 
-                // Debug logging
-                LOGGER.log(getNormalLoggingLevel(), "Processing node: {0}", agentNode.getDisplayName());
-
-                // If the machine is not offline, then don't do anything.
-                if (!azureComputer.isOffline()) {
-                    LOGGER.log(
-                        getNormalLoggingLevel(),
-                        "Node {0} is not offline, skipping", agentNode.getDisplayName());
-                    continue;
-                }
-
-                // If the machine is not idle, don't do anything.
-                // Could have been taken offline by the plugin while still running
-                // builds.
-                // if (!azureComputer.isIdle()) {
-                //     LOGGER.log(getNormalLoggingLevel(),
-                //  "Node {0} is not idle, skipping", agentNode.getDisplayName());
-                //     continue;
-                // }
-
-                // Even if offline, a machine that has been temporarily marked offline
-                // should stay (this could be for investigation).
-                if (azureComputer.isSetOfflineByUser()) {
-                    LOGGER.log(getNormalLoggingLevel(), "Node {0} was set offline by user, skipping",
-                            agentNode.getDisplayName());
-                    continue;
-                }
-
-                // If the machine is in "keep" state, skip
-                if (agentNode.isCleanUpBlocked()) {
-                    LOGGER.log(getNormalLoggingLevel(), "Node {0} blocked to cleanup", agentNode.getDisplayName());
-                    continue;
-                }
-
                 // Check if the virtual machine exists.  If not, it could have been
-                // deleted in the background.  Remove from Jenkins if that is the case.
+                // deleted in the background.  Remove from Jenkins if that is the case
                 LOGGER.log(
                     getNormalLoggingLevel(),
                     "Checking if virtual machine exists for node: {0}", agentNode.getDisplayName());
@@ -518,6 +484,7 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
                         agentNode.getDisplayName(),
                         vmExists});
 
+                // Remove Node if virtual machine does not exist
                 if (!vmExists) {
                     LOGGER.log(getNormalLoggingLevel(),
                             "Node {0} doesn't exist, removing",
@@ -532,6 +499,37 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
                                 "Node {0} could not be removed: {1}",
                                 new Object[]{agentNode.getDisplayName(), e.getMessage()});
                     }
+                    continue;
+                }
+
+                // If the machine is not offline, then don't do anything.
+                if (!azureComputer.isOffline()) {
+                    LOGGER.log(
+                        getNormalLoggingLevel(),
+                        "Node {0} is not offline, skipping", agentNode.getDisplayName());
+                    continue;
+                }
+
+                // If the machine is not idle, don't do anything.
+                // Could have been taken offline by the plugin while still running
+                // builds.
+                if (!azureComputer.isIdle()) {
+                    LOGGER.log(getNormalLoggingLevel(),
+                "Node {0} is not idle, skipping", agentNode.getDisplayName());
+                    continue;
+                }
+
+                // Even if offline, a machine that has been temporarily marked offline
+                // should stay (this could be for investigation).
+                if (azureComputer.isSetOfflineByUser()) {
+                    LOGGER.log(getNormalLoggingLevel(), "Node {0} was set offline by user, skipping",
+                            agentNode.getDisplayName());
+                    continue;
+                }
+
+                // If the machine is in "keep" state, skip
+                if (agentNode.isCleanUpBlocked()) {
+                    LOGGER.log(getNormalLoggingLevel(), "Node {0} blocked to cleanup", agentNode.getDisplayName());
                     continue;
                 }
 

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -489,9 +489,6 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
 
                 // If the machine is not offline, then don't do anything.
                 if (!azureComputer.isOffline()) {
-                    LOGGER.log(
-                        getNormalLoggingLevel(),
-                        "Node {0} is not offline, skipping", agentNode.getDisplayName());
                     continue;
                 }
 
@@ -499,8 +496,6 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
                 // Could have been taken offline by the plugin while still running
                 // builds.
                 if (!azureComputer.isIdle()) {
-                    LOGGER.log(getNormalLoggingLevel(),
-                "Node {0} is not idle, skipping", agentNode.getDisplayName());
                     continue;
                 }
 

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -500,7 +500,7 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
                 // Check if the virtual machine exists.  If not, it could have been
                 // deleted in the background.  Remove from Jenkins if that is the case.
                 LOGGER.log(getNormalLoggingLevel(),
-                    "Checking if virtual machine exists for node: {0}", 
+                    "Checking if virtual machine exists for node: {0}",
                     agentNode.getDisplayName()
                 );
                 if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -499,7 +499,7 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
 
                 // Check if the virtual machine exists.  If not, it could have been
                 // deleted in the background.  Remove from Jenkins if that is the case.
-                LOGGER.log(Level.INFO, "Checking if virtual machine exists for node: {0}", agentNode.getDisplayName());
+                LOGGER.log(getNormalLoggingLevel(), "Checking if virtual machine exists for node: {0}", agentNode.getDisplayName());
                 if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
                     LOGGER.log(getNormalLoggingLevel(),
                             "Node {0} doesn't exist, removing",
@@ -514,14 +514,16 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
                     continue;
                 }
                 // Echo statement to log before the step
-               // LOGGER.log(Level.INFO, "Checking if virtual machine exists for node: {0}", agentNode.getDisplayName());
+               // LOGGER.log(Level.INFO, "Checking if virtual machine exists for node: {0}",
+                // agentNode.getDisplayName());
                // if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
                //     LOGGER.log(Level.INFO, "Node {0} doesn't exist, removing.", agentNode.getDisplayName());
                //     try {
                //         Jenkins.get().removeNode(agentNode);
                //         LOGGER.log(Level.INFO, "Node {0} successfully removed.", agentNode.getDisplayName());
                //     } catch (IOException e) {
-               //         LOGGER.log(Level.WARNING, "Node {0} could not be removed: {1}", new Object[]{agentNode.getDisplayName(), e.getMessage()});
+            //    LOGGER.log(Level.WARNING, "Node {0} could not be removed:
+               //  {1}", new Object[]{agentNode.getDisplayName(), e.getMessage()});
                //     }
                //     continue;
                // }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -472,28 +472,13 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
                 final AzureVMAgent agentNode = azureComputer.getNode();
 
                 // Check if the virtual machine exists.  If not, it could have been
-                // deleted in the background.  Remove from Jenkins if that is the case
-                LOGGER.log(
-                    getNormalLoggingLevel(),
-                    "Checking if virtual machine exists for node: {0}", agentNode.getDisplayName());
-                boolean vmExists = AzureVMManagementServiceDelegate.virtualMachineExists(agentNode);
-                LOGGER.log(
-                    getNormalLoggingLevel(),
-                    "Virtual machine existence check for node {0}: {1}",
-                    new Object[]{
-                        agentNode.getDisplayName(),
-                        vmExists});
-
-                // Remove Node if virtual machine does not exist
-                if (!vmExists) {
+                // deleted in the background.  Remove from Jenkins if that is the case.
+                if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
                     LOGGER.log(getNormalLoggingLevel(),
                             "Node {0} doesn't exist, removing",
                             agentNode.getDisplayName());
                     try {
                         Jenkins.get().removeNode(agentNode);
-                        LOGGER.log(
-                            getNormalLoggingLevel(),
-                            "Node {0} successfully removed", agentNode.getDisplayName());
                     } catch (IOException e) {
                         LOGGER.log(Level.WARNING,
                                 "Node {0} could not be removed: {1}",

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -512,17 +512,16 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
                 //     }
                 //     continue;
                 // }
-             
                 // Echo statement to log before the step
                 System.out.println("Checking if virtual machine exists for node: " + agentNode.getDisplayName());
-             
                 if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
                     System.out.println("Node " + agentNode.getDisplayName() + " doesn't exist, removing.");
                     try {
                         Jenkins.get().removeNode(agentNode);
                         System.out.println("Node " + agentNode.getDisplayName() + " successfully removed.");
                     } catch (IOException e) {
-                        System.out.println("Node " + agentNode.getDisplayName() + " could not be removed: " + e.getMessage());
+                        System.out.println("Node " + agentNode.getDisplayName() + " could not be removed: "
+                                          + e.getMessage());
                     }
                     continue;
                 }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -499,16 +499,30 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
 
                 // Check if the virtual machine exists.  If not, it could have been
                 // deleted in the background.  Remove from Jenkins if that is the case.
+                // if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
+                //     LOGGER.log(getNormalLoggingLevel(),
+                //             "Node {0} doesn't exist, removing",
+                //             agentNode.getDisplayName());
+                //     try {
+                //         Jenkins.get().removeNode(agentNode);
+                //     } catch (IOException e) {
+                //         LOGGER.log(Level.WARNING,
+                //                 "Node {0} could not be removed: {1}",
+                //                 new Object[]{agentNode.getDisplayName(), e.getMessage()});
+                //     }
+                //     continue;
+                // }
+             
+                // Echo statement to log before the step
+                System.out.println("Checking if virtual machine exists for node: " + agentNode.getDisplayName());
+             
                 if (!AzureVMManagementServiceDelegate.virtualMachineExists(agentNode)) {
-                    LOGGER.log(getNormalLoggingLevel(),
-                            "Node {0} doesn't exist, removing",
-                            agentNode.getDisplayName());
+                    System.out.println("Node " + agentNode.getDisplayName() + " doesn't exist, removing.");
                     try {
                         Jenkins.get().removeNode(agentNode);
+                        System.out.println("Node " + agentNode.getDisplayName() + " successfully removed.");
                     } catch (IOException e) {
-                        LOGGER.log(Level.WARNING,
-                                "Node {0} could not be removed: {1}",
-                                new Object[]{agentNode.getDisplayName(), e.getMessage()});
+                        System.out.println("Node " + agentNode.getDisplayName() + " could not be removed: " + e.getMessage());
                     }
                     continue;
                 }


### PR DESCRIPTION
When working with spot instance, when the agent is evicted/removed the node in jenkins is not removed because of this [check](https://github.com/jenkinsci/azure-vm-agents-plugin/blob/37f3eab68cf0f8b2e5e0891d6dec64ee5f435f1c/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java#L480) which causes the build to hang.
If we move the idle check below the vm-exists check this solves the issue.

### Testing done

Tested this change by adding more logging to see what was causing the issue of why the node wasn't being removed when the agent no longer existed.
The logging show it was being stop by the not idle check.
`[FINE][com.microsoft.azure.vmagent.AzureVMAgentCleanUpTask cleanVMs] Node cnp-jenkins-builderse8d030 is not idle, skipping`
I next moved the idle check further down the code and tested removing the agent when the build was running.  This time the clean-up task would remove the node.
`[INFO][com.microsoft.azure.vmagent.AzureVMManagementServiceDelegate virtualMachineExists] Checking VM exists for cnp-jenkins-builderse8d030 
[INFO][com.microsoft.azure.vmagent.AzureVMManagementServiceDelegate virtualMachineExists] cnp-jenkins-builderse8d030 doesnt exist 
[FINE][com.microsoft.azure.vmagent.AzureVMAgentCleanUpTask cleanVMs] Node cnp-jenkins-builderse8d030 doesnt exist, removing `


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
