### PR TITLE
Allow template updates after JCasC configuration generation

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -1479,7 +1479,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
         if (StringUtils.isBlank(newTemplate.getTemplateName())) {
             throw new Descriptor.FormException("Template name is mandatory", "templateName");
         }
-        boolean templateNameExists = azureCloud.templateNameExists(newTemplate.getTemplateName());
+        boolean templateNameExists = azureVMCloud.templateNameExists(newTemplate.getTemplateName());
         if (templateNameExists) {
             throw new Descriptor.FormException("Agent template name must be unique", "templateName");
         }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/504

Guessing its some readResolve error after JCasC generates the objects.
Quite odd though, appears this was just a typo and not intentional though.

### Testing done

Manually tested removing and re-adding after viewing JCasC configuration.
Reproduced before and can't reproduce after

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
