### PR TITLE
Handle SSH launcher not being exported by JCasC

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -228,11 +228,12 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
         this.creationTime = System.currentTimeMillis();
     }
 
-    private static DescribableList<NodeProperty<?>, NodePropertyDescriptor> getNodeProperties(
+    private static List<NodeProperty<?>> getNodeProperties(
             String fqdn, AzureVMAgentTemplate template
     ) {
-        DescribableList<NodeProperty<?>, NodePropertyDescriptor> nodeProperties = template.getNodeProperties();
-        EnvironmentVariablesNodeProperty envVarsNodeProperty = nodeProperties
+        List<NodeProperty<?>> nodeProperties = new ArrayList<>(template.getNodeProperties());
+        DescribableList<NodeProperty<?>, NodePropertyDescriptor> templateNodeProperties = template.getNodeProperties();
+        EnvironmentVariablesNodeProperty envVarsNodeProperty = templateNodeProperties
                 .get(EnvironmentVariablesNodeProperty.class);
 
         List<EnvironmentVariablesNodeProperty.Entry> newEntries = new ArrayList<>();

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -663,13 +663,14 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
                         : template.getImageReference().getGalleryResourceGroup());
         templateProperties.put("osType",
                 isBasic ? defaultProperties.get(Constants.DEFAULT_OS_TYPE) : template.getOsType());
-        boolean isSSH = template.getLauncher() instanceof AzureSSHLauncher;
+        var launcher = template.getLauncher() == null ? new AzureSSHLauncher() : template.getLauncher();
+        boolean isSSH = launcher instanceof AzureSSHLauncher;
         String agentLaunchMethod = isSSH ? Constants.LAUNCH_METHOD_SSH : Constants.LAUNCH_METHOD_JNLP;
         templateProperties.put("agentLaunchMethod",
                 isBasic ? defaultProperties.get(Constants.DEFAULT_LAUNCH_METHOD) : agentLaunchMethod);
         if (isSSH) {
             templateProperties.put("sshConfig",
-                    isBasic ? "" : ((AzureSSHLauncher) template.getLauncher()).getSshConfig());
+                    isBasic ? "" : ((AzureSSHLauncher) launcher).getSshConfig());
         }
         templateProperties.put("initScript",
                 isBasic ? getBasicInitScript(template) : template.getInitScript());

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -1073,6 +1073,7 @@ public final class AzureVMManagementServiceDelegate {
             AzureVMAgentTemplate template,
             String targetScriptName,
             String initScript) throws AzureCloudException {
+        String localInitScript = initScript != null ? initScript : "";
         String targetStorageAccount = template.getStorageAccountName();
         String targetStorageAccountType = template.getStorageAccountType();
         String resourceGroupName = template.getResourceGroupName();
@@ -1100,8 +1101,8 @@ public final class AzureVMManagementServiceDelegate {
             BlobContainerClient container = getCloudBlobContainer(
                     azureClient, resourceGroupName, targetStorageAccount, Constants.CONFIG_CONTAINER_NAME);
             BlobClient blob = container.getBlobClient(targetScriptName);
-            scriptLength = initScript.getBytes(StandardCharsets.UTF_8).length;
-            blob.upload(BinaryData.fromString(initScript).toStream(), scriptLength, true);
+            scriptLength = localInitScript.getBytes(StandardCharsets.UTF_8).length;
+            blob.upload(BinaryData.fromString(localInitScript).toStream(), scriptLength, true);
             return blob.getBlobUrl();
         } catch (Exception e) {
             throw AzureCloudException.create(


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

* Handle SSH launcher not being exported by JCasC
* Handle null init script (as jelly submits empty string and JCasC does null)
* Create a node properties list copy so we don't accidentally add the FQDN variable to the template

Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/567

I wasn't able to figure out why it wasn't being exported, would need to refresh myself on this area of jcasc code and it would take a lot more effort than this simple patch

### Testing done

Tested without providing a launcher in jcasc and it now works

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
