### PR TITLE
Add support for storage account RBAC only access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,18 +23,6 @@
         </license>
     </licenses>
 
-    <developers>
-        <developer>
-            <id>xuzhang</id>
-            <name>Xu Zhang</name>
-            <email>xuzhang3@microsoft.com</email>
-        </developer>
-        <developer>
-            <id>timja</id>
-            <name>Tim Jacomb</name>
-        </developer>
-    </developers>
-
     <scm>
         <connection>scm:git:https://github.com/${gitHubRepo}</connection>
         <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
@@ -45,7 +33,8 @@
     <properties>
         <changelist>9999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/azure-vm-agents-plugin</gitHubRepo>
-        <jenkins.version>2.426.3</jenkins.version>
+        <jenkins.baseline>2.426</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <hpi.compatibleSinceVersion>883</hpi.compatibleSinceVersion>
     </properties>
@@ -54,7 +43,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.426.x</artifactId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
                 <version>3208.vb_21177d4b_cd9</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -71,7 +60,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>azure-credentials</artifactId>
-            <version>293.vb_d506148f506</version>
+            <version>341.v4881e9f4ffea_</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -595,7 +595,7 @@ public class AzureVMCloud extends Cloud {
                                 getServiceDelegate().setVirtualMachineDetails(newAgent, template);
                                 return newAgent;
                             } else {
-                                LOGGER.log(Level.INFO,
+                                LOGGER.log(Level.FINE,
                                         "Deployment {0} not yet finished ({1}): {2}:{3} - waited {4} seconds",
                                         new Object[]{deploymentName, state, type, resource,
                                                 (maxTries - triesLeft) * sleepTimeInSeconds});
@@ -873,7 +873,7 @@ public class AzureVMCloud extends Cloud {
                                 }
 
                                 try {
-                                    LOGGER.log(Level.INFO, "Adding agent {0} to Jenkins nodes",
+                                    LOGGER.log(Level.FINE, "Adding agent {0} to Jenkins nodes",
                                             agent.getNodeName());
                                     // Place the node in blocked state while it starts.
                                     try {
@@ -1282,6 +1282,10 @@ public class AzureVMCloud extends Cloud {
                     resourceGroupName = Constants.DEFAULT_RESOURCE_GROUP_NAME;
                 }
                 AzureResourceManager azureClient = AzureResourceManagerCache.get(azureCredentialsId);
+                if (azureClient == null) {
+                    return FormValidation.error("Cannot get Azure client");
+                }
+
                 final String validationResult = AzureVMManagementServiceDelegate
                         .getInstance(azureClient, azureCredentialsId)
                         .verifyConfiguration(resourceGroupName, deploymentTimeout);
@@ -1317,6 +1321,10 @@ public class AzureVMCloud extends Cloud {
 
             try {
                 final AzureResourceManager azureClient = AzureResourceManagerCache.get(azureCredentialsId);
+                if (azureClient == null) {
+                    return model;
+                }
+
                 Set<String> resourceGroupNames = new HashSet<>();
                 for (ResourceGroup resourceGroup : azureClient.resourceGroups().list()) {
                     resourceGroupNames.add(resourceGroup.name());

--- a/src/main/java/com/microsoft/azure/vmagent/availability/AvailabilitySet.java
+++ b/src/main/java/com/microsoft/azure/vmagent/availability/AvailabilitySet.java
@@ -86,6 +86,9 @@ public class AvailabilitySet extends AzureAvailabilityType {
 
             try {
                 AzureResourceManager azureClient = AzureResourceManagerCache.get(azureCredentialsId);
+                if (azureClient == null) {
+                    return model;
+                }
                 String resourceGroupName = AzureVMCloud.getResourceGroupName(
                         resourceGroupReferenceType, newResourceGroupName, existingResourceGroupName);
                 PagedIterable<com.azure.resourcemanager.compute.models.AvailabilitySet> availabilitySets =

--- a/src/main/java/com/microsoft/azure/vmagent/availability/VirtualMachineScaleSet.java
+++ b/src/main/java/com/microsoft/azure/vmagent/availability/VirtualMachineScaleSet.java
@@ -86,6 +86,9 @@ public class VirtualMachineScaleSet extends AzureAvailabilityType {
 
             try {
                 AzureResourceManager azureClient = AzureResourceManagerCache.get(azureCredentialsId);
+                if (azureClient == null) {
+                    return model;
+                }
                 String resourceGroupName = AzureVMCloud.getResourceGroupName(
                         resourceGroupReferenceType, newResourceGroupName, existingResourceGroupName);
                 PagedIterable<com.azure.resourcemanager.compute.models.VirtualMachineScaleSet> scaleSets =

--- a/src/main/java/com/microsoft/azure/vmagent/util/AzureClientHolder.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/AzureClientHolder.java
@@ -1,5 +1,6 @@
 package com.microsoft.azure.vmagent.util;
 
+import com.azure.resourcemanager.AzureResourceManager;
 import com.microsoft.azure.vmagent.AzureVMManagementServiceDelegate;
 import com.microsoft.jenkins.credentials.AzureResourceManagerCache;
 
@@ -8,6 +9,10 @@ public final class AzureClientHolder {
     }
 
     public static AzureVMManagementServiceDelegate getDelegate(String credentialId) {
-        return AzureVMManagementServiceDelegate.getInstance(AzureResourceManagerCache.get(credentialId), credentialId);
+        AzureResourceManager azureClient = AzureResourceManagerCache.get(credentialId);
+        if (azureClient == null) {
+            return null;
+        }
+        return AzureVMManagementServiceDelegate.getInstance(azureClient, credentialId);
     }
 }

--- a/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
@@ -450,6 +450,9 @@ public final class AzureUtil {
             return true;
         }
         AzureResourceManager defaultClient = AzureResourceManagerCache.get(credentialId);
+        if (defaultClient == null) {
+            return false;
+        }
         PagedIterable<Subscription> subscriptions = defaultClient.subscriptions().list();
         boolean isSubscriptionIdValid = false;
         for (Subscription subscription : subscriptions) {

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/config.jelly
@@ -80,6 +80,13 @@
                  help="/plugin/azure-vm-agents/help-storageAccountName.html">
           <f:select/>
         </f:entry>
+
+        <f:entry
+            title="${%Use Entra authentication to access storage account}"
+            field="useEntraIdForStorageAccount"
+        >
+          <f:checkbox />
+        </f:entry>
       </f:radioBlock>
     </f:entry>
 
@@ -344,6 +351,6 @@
   <l:isAdmin>
     <f:validateButton title="${%Verify_Template}" progress="${%Verifying_Template_MSG}"
                       method="verifyConfiguration"
-                      with="cloudName,templateName,labels,location,virtualMachineSize,storageAccountNameReferenceType,newStorageAccountName,existingStorageAccountName,storageAccountType,noOfParallelJobs,imageTopLevelType,builtInImage,image,osType,id,uri,publisher,offer,sku,version,galleryName,galleryImageDefinition,galleryImageVersion,galleryImageSpecialized,gallerySubscriptionId,galleryResourceGroup,sshConfig,initScript,credentialsId,virtualNetworkName,virtualNetworkResourceGroupName,subnetName,usePrivateIP,nsgName,jvmOptions"/>
+                      with="cloudName,templateName,labels,location,virtualMachineSize,storageAccountNameReferenceType,newStorageAccountName,existingStorageAccountName,useEntraIdForStorageAccount,uamiID,storageAccountType,noOfParallelJobs,imageTopLevelType,builtInImage,image,osType,id,uri,publisher,offer,sku,version,galleryName,galleryImageDefinition,galleryImageVersion,galleryImageSpecialized,gallerySubscriptionId,galleryResourceGroup,sshConfig,initScript,credentialsId,virtualNetworkName,virtualNetworkResourceGroupName,subnetName,usePrivateIP,nsgName,jvmOptions"/>
   </l:isAdmin>
 </j:jelly>

--- a/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/help-useEntraIdForStorageAccount.html
+++ b/src/main/resources/com/microsoft/azure/vmagent/AzureVMAgentTemplate/help-useEntraIdForStorageAccount.html
@@ -1,0 +1,2 @@
+<p>Uses Entra ID authentication instead of shared key.</p>
+<p>Requires user assigned managed identity to be configured in the template and the Storage Blob Data Contributor role assigned to the identity.</p>

--- a/src/test/java/com/microsoft/azure/vmagent/ITAzureVMAgentCleanUpTask.java
+++ b/src/test/java/com/microsoft/azure/vmagent/ITAzureVMAgentCleanUpTask.java
@@ -46,7 +46,8 @@ public class ITAzureVMAgentCleanUpTask extends IntegrationTest {
         final String cloudName = "fake_cloud_name";
         final AzureVMAgentCleanUpTask.DeploymentRegistrar deploymentRegistrar = AzureVMAgentCleanUpTask.DeploymentRegistrar.getInstance();
 
-        deploymentRegistrar.registerDeployment(cloudName, testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null);
+        deploymentRegistrar.registerDeployment(cloudName, testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(),
+                null, false);
         AzureVMAgentCleanUpTask cleanUpMock = spy(AzureVMAgentCleanUpTask.class);
         AzureVMCloud cloudMock = mock(AzureVMCloud.class);
         when(cloudMock.getCloudName()).thenReturn(cloudName);

--- a/src/test/java/com/microsoft/azure/vmagent/ITAzureVMManagementServiceDelegate.java
+++ b/src/test/java/com/microsoft/azure/vmagent/ITAzureVMManagementServiceDelegate.java
@@ -118,7 +118,8 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
         when(deploymentRegistrar.getDeploymentTag()).thenReturn(new AzureUtil.DeploymentTag("some_tag/123"));
         deploymentInfo = createDefaultDeployment(numberOfAgents, deploymentRegistrar);
 
-        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null);
+        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup,
+                deploymentInfo.getDeploymentName(), null, false);
         Network actualVNet = null;
         StorageAccount actualStorageAcc = null;
         try {
@@ -192,7 +193,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
         when(deploymentRegistrar.getDeploymentTag()).thenReturn(new AzureUtil.DeploymentTag("some_tag/123"));
         AzureVMDeploymentInfo deploymentInfo = createDefaultDeployment(1, false, deploymentRegistrar);
 
-        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null);
+        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null, false);
         Network actualVNet = null;
         StorageAccount actualStorageAcc = null;
         try {
@@ -249,7 +250,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
         AzureVMDeploymentInfo deploymentInfo;
         deploymentInfo = createDefaultDeployment(1, deploymentRegistrar);
 
-        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null);
+        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null, false);
         Network actualVNet = null;
         StorageAccount actualStorageAcc = null;
         try {
@@ -294,7 +295,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
         AzureVMDeploymentInfo deploymentInfo;
         deploymentInfo = createDefaultDeployment(1, true, true, false, false, "", deploymentRegistrar);
 
-        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null);
+        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null, false);
         Network actualVNet = null;
         StorageAccount actualStorageAcc = null;
         try {
@@ -355,7 +356,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
         AzureVMDeploymentInfo deploymentInfo;
         deploymentInfo = createDefaultDeployment(1, deploymentRegistrar);
 
-        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null);
+        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null, false);
         Network actualVNet = null;
         StorageAccount actualStorageAcc = null;
         try {
@@ -403,7 +404,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
         AzureVMDeploymentInfo deploymentInfo;
         deploymentInfo = createDefaultDeployment(1, deploymentRegistrar);
 
-        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null);
+        verify(deploymentRegistrar).registerDeployment("testCloud", testEnv.azureResourceGroup, deploymentInfo.getDeploymentName(), null, false);
         Network actualVNet = null;
         StorageAccount actualStorageAcc = null;
         try {
@@ -719,7 +720,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
             VirtualMachine vm = createAzureVM(vmName);
             ExecutionEngine executionEngineMock = mock(ExecutionEngine.class);
 
-            delegate.terminateVirtualMachine(vmName, testEnv.azureResourceGroup, false, executionEngineMock);
+            delegate.terminateVirtualMachine(vmName, testEnv.azureResourceGroup, false);
 
             verify(executionEngineMock).executeAsync(any(Callable.class), any(RetryStrategy.class));
 
@@ -738,7 +739,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
             ExecutionEngine executionEngineMock = mock(ExecutionEngine.class);
 
             //VM is missing so terminateVirtualMachine should be a no-op and no exception should be thrown
-            delegate.terminateVirtualMachine(vmName, testEnv.azureResourceGroup, false, executionEngineMock);
+            delegate.terminateVirtualMachine(vmName, testEnv.azureResourceGroup, false);
             verify(executionEngineMock).executeAsync(any(Callable.class), any(RetryStrategy.class));
 
         } catch (Exception e) {
@@ -1100,8 +1101,8 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
             final String deletedContainerBlobURI = uploadFile(storageAccount, fileName, data, containerName_from_jenkins);
             final String existingContainerBlobURI = uploadFile(storageAccount, fileName, data, containerName_from_user);
 
-            delegate.removeStorageBlob(new URI(deletedContainerBlobURI), testEnv.azureResourceGroup);
-            delegate.removeStorageBlob(new URI(existingContainerBlobURI), testEnv.azureResourceGroup);
+            delegate.removeStorageBlob(new URI(deletedContainerBlobURI), testEnv.azureResourceGroup, null, false);
+            delegate.removeStorageBlob(new URI(existingContainerBlobURI), testEnv.azureResourceGroup, null, false);
 
             Assert.assertFalse(containerExists(deletedContainerBlobURI)); // both container and blob are missing
             Assert.assertTrue(containerExists(existingContainerBlobURI)); // the container is there, but the blob is missing
@@ -1151,7 +1152,7 @@ public class ITAzureVMManagementServiceDelegate extends IntegrationTest {
             final String blobToBeDeleted = uploadFile(storageAccount, fileName1, data, containerName);
             final String notDeletedBlob = uploadFile(storageAccount, fileName2, data, containerName);
 
-            delegate.removeStorageBlob(new URI(blobToBeDeleted), testEnv.azureResourceGroup);
+            delegate.removeStorageBlob(new URI(blobToBeDeleted), testEnv.azureResourceGroup, null, false);
 
             Assert.assertTrue(containerExists(blobToBeDeleted));
             Assert.assertFalse(blobExists(blobToBeDeleted));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

downstream of https://github.com/jenkinsci/azure-credentials-plugin/pull/271

Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/478

This only appears to affect Windows VMs or VMs with an unmanaged disk

### Testing done

Created both a template that uses a storage account with key authentication and RBAC only

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
