### PR TITLE
Add Windows 2025 support for built-in images

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -1737,6 +1737,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
             model.add(Constants.UBUNTU_2404_LTS);
             model.add(Constants.UBUNTU_2204_LTS);
             model.add(Constants.UBUNTU_2004_LTS);
+            model.add(Constants.WINDOWS_SERVER_2025);
             model.add(Constants.WINDOWS_SERVER_2022);
             model.add(Constants.WINDOWS_SERVER_2019);
             model.add(Constants.WINDOWS_SERVER_2016);

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -1653,6 +1653,8 @@ public final class AzureVMManagementServiceDelegate {
                 imageProperties("MicrosoftWindowsServer", "WindowsServer", "2019-Datacenter", "2019-Datacenter-with-Containers", Constants.OS_TYPE_WINDOWS));
         imageProperties.put(Constants.WINDOWS_SERVER_2022,
                 imageProperties("MicrosoftWindowsServer", "WindowsServer", "2022-datacenter-azure-edition-core", "2022-datacenter-azure-edition-core", Constants.OS_TYPE_WINDOWS));
+        imageProperties.put(Constants.WINDOWS_SERVER_2025,
+                imageProperties("MicrosoftWindowsServer", "WindowsServer", "2025-datacenter-azure-edition-core", "2025-datacenter-azure-edition-core", Constants.OS_TYPE_WINDOWS));
         imageProperties.put(Constants.UBUNTU_2004_LTS,
                 imageProperties("canonical", "0001-com-ubuntu-server-focal", "20_04-lts-gen2", "20_04-lts-gen2", Constants.OS_TYPE_LINUX));
         imageProperties.put(Constants.UBUNTU_2204_LTS,
@@ -1686,6 +1688,7 @@ public final class AzureVMManagementServiceDelegate {
         tools.put(Constants.WINDOWS_SERVER_2016, new HashMap<>());
         tools.put(Constants.WINDOWS_SERVER_2019, new HashMap<>());
         tools.put(Constants.WINDOWS_SERVER_2022, new HashMap<>());
+        tools.put(Constants.WINDOWS_SERVER_2025, new HashMap<>());
         tools.put(Constants.UBUNTU_2004_LTS, new HashMap<>());
         tools.put(Constants.UBUNTU_2204_LTS, new HashMap<>());
         tools.put(Constants.UBUNTU_2404_LTS, new HashMap<>());
@@ -1693,6 +1696,7 @@ public final class AzureVMManagementServiceDelegate {
             windows(Constants.WINDOWS_SERVER_2016, tools);
             windows(Constants.WINDOWS_SERVER_2019, tools);
             windows(Constants.WINDOWS_SERVER_2022, tools);
+            windows(Constants.WINDOWS_SERVER_2025, tools);
             ubuntu(Constants.UBUNTU_2004_LTS, tools);
             ubuntu(Constants.UBUNTU_2204_LTS, tools);
             ubuntu(Constants.UBUNTU_2404_LTS, tools);

--- a/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
@@ -128,6 +128,7 @@ public final class Constants {
     /**
      * Built In Image.
      */
+    public static final String WINDOWS_SERVER_2025 = "Windows Server 2025";
     public static final String WINDOWS_SERVER_2022 = "Windows Server 2022";
     public static final String WINDOWS_SERVER_2019 = "Windows Server 2019";
     public static final String WINDOWS_SERVER_2016 = "Windows Server 2016";


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/605

Note: It falsely reports windows 22 on the Jenkins nodes page and in `mvn --version` due to https://bugs.openjdk.org/browse/JDK-8340387

This is due for release in e.g. 17.0.14 in January 2025

### Testing done

Ran an agent on Windows 2025

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
