### PR TITLE
Fix starting agent after idle shutdown

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -403,6 +403,11 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
     public void clearCleanUpAction() {
         setCleanUpAction(CleanUpAction.DEFAULT);
         setCleanUpReason(null);
+
+        Computer computer = toComputer();
+        if (computer != null) {
+            computer.setTemporaryOfflineCause(null);
+        }
     }
 
     /**
@@ -424,7 +429,11 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
         AzureVMComputer computer = (AzureVMComputer) this.toComputer();
         if (computer != null) {
             // Set the machine temporarily offline machine with an offline reason.
-            computer.setTemporarilyOffline(true, OfflineCause.create(reason));
+            if (action == CleanUpAction.SHUTDOWN) {
+                computer.setTemporaryOfflineCause(new OfflineCause.IdleOfflineCause());
+            } else {
+                computer.setTemporaryOfflineCause(OfflineCause.create(reason));
+            }
         }
         setCleanUpAction(action);
         setCleanUpReason(reason);
@@ -570,7 +579,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
 
     public synchronized void shutdown(Localizable reason) {
         if (isEligibleForReuse()) {
-            LOGGER.log(Level.INFO, "Agent {0} is always shut down", this.
+            LOGGER.log(Level.INFO, "Agent {0} is shut down", this.
                     getDisplayName());
             return;
         }
@@ -583,7 +592,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
             return;
         }
         computer.setAcceptingTasks(false);
-        computer.disconnect(OfflineCause.create(reason));
+        computer.setTemporaryOfflineCause(new OfflineCause.IdleOfflineCause());
         LOGGER.log(Level.INFO, "Shutting down agent {0}", this.getDisplayName());
 
         AzureVMManagementServiceDelegate serviceDelegate = getServiceDelegate();
@@ -615,8 +624,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
 
         ComputerLauncher launcher = computer.getLauncher();
 
-        if ((launcher instanceof AzureVMAgentSSHLauncher)) {
-            AzureVMAgentSSHLauncher azureLauncher = (AzureVMAgentSSHLauncher) launcher;
+        if ((launcher instanceof AzureVMAgentSSHLauncher azureLauncher)) {
             PrintStream terminateStream = new LogTaskListener(LOGGER, Level.INFO).getLogger();
 
             final boolean isUnix = this.getOsType().equals(OperatingSystemTypes.LINUX);
@@ -649,7 +657,7 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
                 }
                 if (!skipTerminateScript
                         && azureLauncher.executeRemoteCommand(this, command, terminateStream, isUnix) != 0) {
-                    LOGGER.info("Terminate script is not null, " + "preparing to execute script remotely");
+                    LOGGER.info("Terminate script present for " + computer.getName() + " preparing to execute script remotely");
                     if (isUnix) {
                         azureLauncher.copyFileToRemote(
                                 this,

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgent.java
@@ -657,7 +657,8 @@ public class AzureVMAgent extends AbstractCloudSlave implements TrackedItem {
                 }
                 if (!skipTerminateScript
                         && azureLauncher.executeRemoteCommand(this, command, terminateStream, isUnix) != 0) {
-                    LOGGER.info("Terminate script present for " + computer.getName() + " preparing to execute script remotely");
+                    LOGGER.info("Terminate script present for " + computer.getName()
+                    + " preparing to execute script remotely");
                     if (isUnix) {
                         azureLauncher.copyFileToRemote(
                                 this,

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentCleanUpTask.java
@@ -484,12 +484,17 @@ public class AzureVMAgentCleanUpTask extends AsyncPeriodicWork {
     private void cleanVMs(ExecutionEngine executionEngine) {
         LOGGER.log(getNormalLoggingLevel(), "Beginning");
         for (Computer computer : Jenkins.get().getComputers()) {
-            if (computer instanceof AzureVMComputer) {
-                AzureVMComputer azureComputer = (AzureVMComputer) computer;
+            if (computer instanceof AzureVMComputer azureComputer) {
                 final AzureVMAgent agentNode = azureComputer.getNode();
 
                 // If the machine is not offline, then don't do anything.
                 if (!azureComputer.isOffline()) {
+                    continue;
+                }
+
+                if (agentNode == null) {
+                    LOGGER.log(getNormalLoggingLevel(), "Node {0} is missing, skipping",
+                            azureComputer.getDisplayName());
                     continue;
                 }
 

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -657,10 +657,8 @@ public class AzureVMCloud extends Cloud {
             if (numberOfAgents == 0) {
                 break;
             }
-            if (agentComputer instanceof AzureVMComputer && agentComputer.isOffline()) {
-                final AzureVMComputer azureComputer = (AzureVMComputer) agentComputer;
+            if (agentComputer instanceof AzureVMComputer azureComputer && agentComputer.isOffline()) {
                 final AzureVMAgent agentNode = azureComputer.getNode();
-
                 if (agentNode != null && isNodeEligibleForReuse(agentNode, template)) {
                     LOGGER.log(Level.FINE, "Agent computer eligible for reuse {0}", agentComputer.getName());
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

Configured agents to shutdown on idle and then ran a new build after the agent had been shutdown.
Previously the agent would start, be brought online and then immediately offline and the job wouldn't be scheduled to it. Eventually another agent would be provisioned.

This was because the offline state wasn't being cleared.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
