### PR TITLE
More resilient no provision on shutdown

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -634,6 +634,12 @@ public class AzureVMCloud extends Cloud {
         LOGGER.log(Level.FINE, "Starting for label {0} workLoad {1}",
                 new Object[]{cloudState.getLabel(), workLoad}
         );
+
+        if (Jenkins.get().isQuietingDown()) {
+            LOGGER.log(Level.FINE, "Skipping provision as Jenkins is in quiet-down");
+            return Collections.emptyList();
+        }
+
         final AzureVMAgentTemplate template = AzureVMCloud.this.getAzureAgentTemplate(cloudState.getLabel());
 
         // round up the number of required machine

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMNoDelayProvisionerStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMNoDelayProvisionerStrategy.java
@@ -48,6 +48,11 @@ public class AzureVMNoDelayProvisionerStrategy extends NodeProvisioner.Strategy 
             return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
         }
 
+        if (Jenkins.get().isQuietingDown()) {
+            LOGGER.log(Level.FINE, "Skipping provision as Jenkins is quieting down");
+            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        }
+
         final Label label = strategyState.getLabel();
 
         LoadStatistics.LoadStatisticsSnapshot snapshot = strategyState.getSnapshot();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/224

Quite hard to trigger this although I did manage to once get the node provisioner trying to provision while it was in prepare for shutdown.

This should make it silently skip it

### Testing done

Haven't been able to reproduce since I put the checks in but it should work

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
