### PR TITLE
Fix scaling issues and force private IP usage when usePrivateIP is set

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -691,6 +691,7 @@ public class AzureVMCloud extends Cloud {
                                                     getServiceDelegate().setVirtualMachineDetails(
                                                             agentNode, template);
                                                     Jenkins.get().addNode(agentNode);
+                                                    azureComputer.setTemporaryOfflineCause(null);
                                                     if (agentNode.getAgentLaunchMethod().equalsIgnoreCase("SSH")) {
                                                         retrySshConnect(azureComputer);
                                                     } else { // Wait until node is online

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudBaseRetentionStrategy.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudBaseRetentionStrategy.java
@@ -19,7 +19,7 @@ public abstract class AzureVMCloudBaseRetentionStrategy extends RetentionStrateg
             Computer.threadPoolForRemoting.submit(new Runnable() {
                 @Override
                 public void run() {
-                    if (agent.getTemplate().isShutdownOnIdle()) {
+                    if (agent.getTemplate().isShutdownOnIdle() && !agent.isCleanUpBlocked()) {
                         agent.setEligibleForReuse(false);
                         agent.shutdown(agent.getCleanUpReason());
                         agent.blockCleanUpAction();

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -1169,9 +1169,9 @@ public final class AzureVMManagementServiceDelegate {
         String publicIPStr = "";
         String privateIP = vm.getPrimaryNetworkInterface().primaryPrivateIP();
         String fqdn;
-        if (publicIP == null) {
+        if (publicIP == null || template.getUsePrivateIP()) {
             fqdn = privateIP;
-            LOGGER.log(Level.INFO, "The Azure agent doesn't have a public IP. Will use the private IP");
+            LOGGER.log(Level.INFO, "The Azure agent doesn't have a public IP or usePrivateIP is set. Will use the private IP");
         } else {
             fqdn = publicIP.fqdn();
             publicIPStr = publicIP.ipAddress();


### PR DESCRIPTION
 * Fix fleet scaling with shutdownOnIdle by cleaning up temporaryOffline state
 * Ensure private IP is always used when usePrivateIP is set
 * Prevent premature VM shutdown during initial VM creation for shutdownOnIdle