### PR TITLE
Allow . in resource group name

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -2004,7 +2004,8 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
 
             String result = delegate
                     .verifyConfiguration(cloud.getResourceGroupName(),
-                            Constants.RESOURCE_GROUP_REFERENCE_TYPE_EXISTING.equals(cloud.getResourceGroupReferenceType()),
+                            Constants.RESOURCE_GROUP_REFERENCE_TYPE_EXISTING
+                                    .equals(cloud.getResourceGroupReferenceType()),
                             String.valueOf(cloud.getDeploymentTimeout()));
             if (!result.equals(Constants.OP_SUCCESS)) {
                 return FormValidation.error(result);

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMAgentTemplate.java
@@ -1997,10 +1997,15 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
                             galleryResourceGroup,
                             gallerySubscriptionId});
 
-            // First validate the subscription info.  If it is not correct,
-            // then we can't validate the
-            String result = AzureClientHolder.getDelegate(cloud.getAzureCredentialsId())
-                    .verifyConfiguration(cloud.getResourceGroupName(), String.valueOf(cloud.getDeploymentTimeout()));
+            AzureVMManagementServiceDelegate delegate = AzureClientHolder.getDelegate(cloud.getAzureCredentialsId());
+            if (delegate == null) {
+                return FormValidation.error("Azure credentials are not configured or are invalid.");
+            }
+
+            String result = delegate
+                    .verifyConfiguration(cloud.getResourceGroupName(),
+                            Constants.RESOURCE_GROUP_REFERENCE_TYPE_EXISTING.equals(cloud.getResourceGroupReferenceType()),
+                            String.valueOf(cloud.getDeploymentTimeout()));
             if (!result.equals(Constants.OP_SUCCESS)) {
                 return FormValidation.error(result);
             }
@@ -2017,7 +2022,7 @@ public class AzureVMAgentTemplate implements Describable<AzureVMAgentTemplate>, 
                 azureComputerLauncher.setSshConfig(sshConfig);
             }
 
-            final List<String> errors = AzureClientHolder.getDelegate(cloud.getAzureCredentialsId()).verifyTemplate(
+            final List<String> errors = delegate.verifyTemplate(
                     templateName,
                     labels,
                     location,

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -1300,7 +1300,10 @@ public class AzureVMCloud extends Cloud {
 
                 final String validationResult = AzureVMManagementServiceDelegate
                         .getInstance(azureClient, azureCredentialsId)
-                        .verifyConfiguration(resourceGroupName, Constants.RESOURCE_GROUP_REFERENCE_TYPE_EXISTING.equals(resourceGroupReferenceType), deploymentTimeout);
+                        .verifyConfiguration(resourceGroupName,
+                                Constants.RESOURCE_GROUP_REFERENCE_TYPE_EXISTING.equals(resourceGroupReferenceType),
+                                deploymentTimeout
+                        );
                 if (!validationResult.equalsIgnoreCase(Constants.OP_SUCCESS)) {
                     return FormValidation.error(validationResult);
                 }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloud.java
@@ -1300,7 +1300,7 @@ public class AzureVMCloud extends Cloud {
 
                 final String validationResult = AzureVMManagementServiceDelegate
                         .getInstance(azureClient, azureCredentialsId)
-                        .verifyConfiguration(resourceGroupName, deploymentTimeout);
+                        .verifyConfiguration(resourceGroupName, Constants.RESOURCE_GROUP_REFERENCE_TYPE_EXISTING.equals(resourceGroupReferenceType), deploymentTimeout);
                 if (!validationResult.equalsIgnoreCase(Constants.OP_SUCCESS)) {
                     return FormValidation.error(validationResult);
                 }

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudVerificationTask.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMCloudVerificationTask.java
@@ -170,6 +170,7 @@ public final class AzureVMCloudVerificationTask extends AsyncPeriodicWork {
         // Check the sub and off we go
         String result = cloud.getServiceDelegate().verifyConfiguration(
                 cloud.getResourceGroupName(),
+                Constants.RESOURCE_GROUP_REFERENCE_TYPE_EXISTING.equals(cloud.getResourceGroupReferenceType()),
                 Integer.toString(cloud.getDeploymentTimeout()));
         if (!Constants.OP_SUCCESS.equals(result)) {
             LOGGER.log(getStaticNormalLoggingLevel(), "AzureVMCloudVerificationTask: verifyConfiguration: {0}", result);

--- a/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
+++ b/src/main/java/com/microsoft/azure/vmagent/AzureVMManagementServiceDelegate.java
@@ -249,7 +249,9 @@ public final class AzureVMManagementServiceDelegate {
             final boolean encryptionAtHost = template.isEncryptionAtHost();
             final int osDiskSize = template.getOsDiskSize();
 
-            if (!template.getResourceGroupName().matches(Constants.DEFAULT_RESOURCE_GROUP_PATTERN)) {
+            if (
+                    Constants.RESOURCE_GROUP_REFERENCE_TYPE_NEW.equals(template.getResourceGroupReferenceType()) &&
+                            !template.getResourceGroupName().matches(Constants.DEFAULT_RESOURCE_GROUP_PATTERN)) {
                 LOGGER.log(Level.SEVERE, "ResourceGroup Name {0} is invalid. It should be 1-64 alphanumeric characters",
                         new Object[]{template.getResourceGroupName()});
                 throw new RuntimeException("ResourceGroup Name is invalid");
@@ -1799,11 +1801,13 @@ public final class AzureVMManagementServiceDelegate {
      * Validates certificate configuration.
      *
      * @param resourceGroupName Resource group name.
+     * @param existingResourceGroup If the resource group already exists then skip validating it.
      * @param timeOut           Timeout of the verification.
      * @return Verification result.
      */
     public String verifyConfiguration(
             String resourceGroupName,
+            boolean existingResourceGroup,
             String timeOut) {
         try {
             if (!AzureUtil.isValidTimeOut(timeOut)) {
@@ -1811,12 +1815,11 @@ public final class AzureVMManagementServiceDelegate {
                         + Constants.DEFAULT_DEPLOYMENT_TIMEOUT_SEC;
             }
 
-            if (!AzureUtil.isValidResourceGroupName(resourceGroupName)) {
+            if (!existingResourceGroup && !AzureUtil.isValidResourceGroupName(resourceGroupName)) {
                 return "Error: " + Messages.Azure_GC_Template_ResourceGroupName_Err();
             }
 
-            if (!(AzureUtil.isValidTimeOut(timeOut)
-                    && AzureUtil.isValidResourceGroupName(resourceGroupName))) {
+            if (!AzureUtil.isValidTimeOut(timeOut)) {
                     return Messages.Azure_GC_Template_Val_Profile_Err();
             }
         } catch (Exception e) {

--- a/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/Constants.java
@@ -240,7 +240,7 @@ public final class Constants {
 
     public static final String DEFAULT_SUBNET_NAME = "jenkinsarm-snet";
 
-    public static final String DEFAULT_RESOURCE_GROUP_PATTERN = "^[a-zA-Z0-9][a-zA-Z\\-_0-9]{0,62}[a-zA-Z0-9]$";
+    public static final String DEFAULT_RESOURCE_GROUP_PATTERN = "^[a-zA-Z0-9][a-zA-Z\\-\\._0-9]{0,62}[a-zA-Z0-9]$";
 
     public static final String AZURE_JENKINS_TAG_NAME = "JenkinsManagedTag";
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fixes https://github.com/jenkinsci/azure-vm-agents-plugin/issues/684

I also removed all validation of 'existing' resource groups, as if they exist in Azure its not our place to validate it

### Testing done

Tested with a resource group name including a ., I haven't deployed a VM but through code inspection it looks fine.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
