### PR TITLE
Update Jenkins baseline to 2.555.3 and require Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
+    [platform: 'linux', jdk: 25],
     [platform: 'linux', jdk: 21],
-    [platform: 'linux', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <changelist>9999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/azure-vm-agents-plugin</gitHubRepo>
-        <jenkins.baseline>2.516</jenkins.baseline>
+        <jenkins.baseline>2.555</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <hpi.compatibleSinceVersion>883</hpi.compatibleSinceVersion>
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>6210.v69ea_fd8a_f010</version>
+                <version>6931.vea_a_b_c6fd017d</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Update the Jenkins baseline from 2.516.3 to 2.555.3, one of the [currently recommended versions](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions).

## What's changed

- `jenkins.baseline` 2.516 -> 2.555, and the plugin BOM to `bom-2.555.x`.
- Jenkins 2.555.1 and newer require Java 21, so the JDK 17 build had to move: `linux/21, linux/17` -> `linux/25, linux/21`, per the [Java support policy](https://www.jenkins.io/doc/book/platform-information/support-policy-java/).

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk baseline update across the plugins I maintain. If anything here looks wrong, please comment on this PR.
